### PR TITLE
Final integration

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,7 +25,8 @@ gulp.task('test', function() {
 });
 
 gulp.task('lint', function() {
-  return gulp.src(['*.js', 'lib/**/*.js', 'src/**/*.js', 'test/**/*.js'])
+  return gulp.src(
+    ['*.js', 'scripts/**/*.js', 'lib/**/*.js', 'src/**/*.js', 'test/**/*.js'])
     .pipe(jshint())
     .pipe(jshint.reporter('default'));
 });

--- a/index.js
+++ b/index.js
@@ -1,0 +1,8 @@
+/* jshint node: true */
+'use strict';
+
+var path = require('path');
+
+module.exports = function(robot) {
+  robot.loadFile(path.resolve(__dirname, 'scripts'), 'slack-github-issues');
+};

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "gulp-mocha": "^2.2.0",
     "hubot": "^2.17.0",
     "hubot-slack": "^3.4.2",
+    "hubot-test-helper": "^1.3.0",
     "jshint": "^2.8.0",
     "mocha": "^2.3.4",
     "sinon": "^1.17.2",

--- a/scripts/slack-github-issues.js
+++ b/scripts/slack-github-issues.js
@@ -1,0 +1,34 @@
+// jshint node: true
+//
+// Description:
+//   Uses the Slack Real Time Messaging API to file GitHub issues
+//
+// Configuration:
+//   HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH
+//
+// Commands:
+//   hubot foobar - baz quux
+//
+// Author:
+//   mbland
+
+'use strict';
+
+var Config = require('../lib/config.js');
+var SlackClient = require('../lib/slack-client.js');
+var GitHubClient = require('../lib/github-client.js');
+var Middleware = require('../lib/middleware.js');
+
+module.exports = function(robot) {
+  var config = new Config(),
+      impl = new Middleware(
+        config.rules,
+        new SlackClient(robot.adapter.client),
+        new GitHubClient(config)),
+      middleware = function(context, next, done) {
+        impl.execute(context, next, done);
+      };
+
+  middleware.impl = impl;
+  robot.receiveMiddleware(middleware);
+};

--- a/test/hubot-smoke-test.bash
+++ b/test/hubot-smoke-test.bash
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+# Hack per:
+# http://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+pushd $(dirname $0) >/dev/null
+PACKAGE_ROOT=$(dirname $(pwd -P))
+popd >/dev/null
+
+export HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH="${PACKAGE_ROOT}/test/helpers/test-config.json"
+
+COFFEE=${PACKAGE_ROOT}/node_modules/coffee-script/bin/coffee
+echo -n "Executing hubot-smoke-test: "
+exec ${COFFEE} ${PACKAGE_ROOT}/node_modules/hubot/bin/hubot -t

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -1,0 +1,109 @@
+/* jshint node: true */
+/* jshint mocha: true */
+
+'use strict';
+
+var Helper = require('hubot-test-helper');
+var scriptHelper = new Helper('../scripts/slack-github-issues.js');
+
+var helpers = require('./helpers');
+var testConfig = require('./helpers/test-config.json');
+var SlackClient = require('../lib/slack-client');
+var GitHubClient = require('../lib/github-client');
+var FakeSlackClient = require('./helpers/fake-slack-client');
+var FakeGitHubApi = require('./helpers/fake-github-api');
+
+var path = require('path');
+var chai = require('chai');
+
+chai.should();
+
+describe('Integration test', function() {
+  var middlewareImpl = null,
+      slackClient = new SlackClient(new FakeSlackClient('handbook')),
+      githubParams = helpers.githubParams();
+
+  before(function() {
+    process.env.HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH = path.join(
+      __dirname, 'helpers', 'test-config.json');
+    process.env.HUBOT_GITHUB_TOKEN = '<18F-github-token>';
+  });
+
+  after(function() {
+    delete process.env.HUBOT_GITHUB_TOKEN;
+    delete process.env.HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH;
+  });
+
+  beforeEach(function() {
+    var that = this;
+
+    this.room = scriptHelper.createRoom({ name: 'handbook' });
+    middlewareImpl = this.room.robot.middleware.receive.stack[0].impl;
+    middlewareImpl.slackClient = slackClient;
+
+    this.room.user.react = function(userName, reaction) {
+      return new Promise(function(resolve) {
+        var reactionMessage = helpers.reactionAddedMessage(),
+            rawMessage = reactionMessage.rawMessage;
+
+        that.room.messages.push([userName, reaction]);
+        reactionMessage.user.name = userName;
+        rawMessage.name = reaction;
+        rawMessage.item.message.reactions[0].name = reaction;
+        that.room.robot.receive(reactionMessage, resolve);
+      });
+    };
+  });
+
+  afterEach(function() {
+    this.room.destroy();
+  });
+
+  context('an evergreen_tree reaction to a message', function() {
+    beforeEach(function() {
+      var githubApi = new FakeGitHubApi(
+        helpers.metadata().url, '', githubParams);
+
+      middlewareImpl.githubClient = new GitHubClient(testConfig, githubApi);
+      return this.room.user.react('mikebland', 'evergreen_tree');
+    });
+
+    it('should create a GitHub issue', function() {
+      this.room.messages.should.eql([
+        ['mikebland', 'evergreen_tree'],
+        ['hubot', '@mikebland created: ' + helpers.metadata().url]
+      ]);
+    });
+  });
+
+  context('a evergreen_tree reaction to a message', function() {
+    beforeEach(function() {
+      var githubApi = new FakeGitHubApi(null, 'test failure', githubParams);
+
+      middlewareImpl.githubClient = new GitHubClient(testConfig, githubApi);
+      return this.room.user.react('mikebland', 'evergreen_tree');
+    });
+
+    it('should fail to create a GitHub issue', function() {
+      this.room.messages.should.eql([
+        ['mikebland', 'evergreen_tree'],
+        ['hubot', '@mikebland failed to create a GitHub issue ' +
+         'in 18F/handbook: test failure']
+      ]);
+    });
+  });
+
+  context('a message receiving another reaction', function() {
+    beforeEach(function() {
+      var githubApi = new FakeGitHubApi(
+        null, 'should not happen', githubParams);
+
+      middlewareImpl.githubClient = new GitHubClient(testConfig, githubApi);
+      return this.room.user.react('mikebland', 'sad-face');
+    });
+
+    it('should be ignored', function() {
+      this.room.messages.should.eql([['mikebland', 'sad-face']]);
+    });
+  });
+});


### PR DESCRIPTION
This is a fully-operational and tested [Hubot](https://hubot.github.com/) plugin as of this PR, but currently it will do nothing if deployed to production. This is because the current versions of [slack-client](https://www.npmjs.com/package/slack-client) and [hubot-slack](https://www.npmjs.com/package/hubot-slack) do not pass through the `reaction_added` message.

I may cherry-pick commits from this branch to other branches/PRs, squashing and shuffling and `push -f`ing as I go, so be warned.

## Deployment questions

@afeld (or a nominee of your choosing), I'd like to know of the feasibility of deploying a `config.json` to production without checking it directly into [18F/18f-bot](https://github.com/18F/18f-bot), or if I should extract the GitHub token as an env var instead. Also wondering how comfortable y'all'd be switching 18F/18f-bot to an 18F fork of `hubot-slack` to support this. Maybe we can grab a half-hour to chat about deployment issues in real-time?

## Testing

`test/integration-test.coffee` relies on some clever hacking to emulate this missing behavior in order to exercise `scripts/slack-github-issues.coffee` end-to-end. Definitely getting a hell of a lot of material out of this for [18F/unit-testing-node](https://github.com/18F/unit-testing-node/), that's for sure.

## Future-proofing

There is a [2.x rewrite of slack-client](https://github.com/l12s/node-slack-client) underway. In the process of developing this branch, I actually adapted the code to use the new interface first, but decided to return to v1.5.0 and encapsulate the differences inside a new `SlackClient` abstraction in this package.

## Coordinating

What I plan to do next is to make 18F forks of slack-client and hubot-slack, just to pass the `reaction_added` message through. I'll get in touch with the [slackhq](https://github.com/slackhq/) folks to let them know what we're up to, in case that motivates them to stabilize the new interface sooner than later.

cc: @ccostino @jeremiak @mtorres253 @andrewmaier @melodykramer 