### PR TITLE
Pass arguments to `gulp test` via `npm test`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-- "5.2"
+- "node"
 - "4.2"
-- "0.12.7"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,14 +1,26 @@
 /* jshint node: true */
 
 var gulp = require('gulp');
+var yargs = require('yargs');
 var mocha = require('gulp-mocha');
 var jshint = require('gulp-jshint');
 
+function buildArgs(args) {
+  var argName, skipArgs = { _: true, '$0': true };
+
+  for (argName in yargs.argv) {
+    if (yargs.argv.hasOwnProperty(argName) && !skipArgs[argName]) {
+      args[argName] = yargs.argv[argName];
+    }
+  }
+  return args;
+}
+
 gulp.task('test', function() {
-  return gulp.src('./test/*.js', {read: false})
+  return gulp.src(['./test/*.js', './test/*.coffee'], {read: false})
     // Reporters:
     // https://github.com/mochajs/mocha/blob/master/lib/reporters/index.js
-    .pipe(mocha({reporter: 'spec'}));
+    .pipe(mocha(buildArgs({ reporter: 'spec' })));
 });
 
 gulp.task('lint', function() {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "gulp-jshint": "^2.0.0",
     "gulp-mocha": "^2.2.0",
     "jshint": "^2.8.0",
-    "mocha": "^2.3.4"
+    "mocha": "^2.3.4",
+    "yargs": "^3.31.0"
   },
   "scripts": {
     "test": "gulp test",


### PR DESCRIPTION
This enables command-line usage such as:

```sh
$ npm test -- --grep 'only run tests matching this pattern'
```

cc: @ccostino @jeremiak