### PR TITLE
Switch slack-client dependency to 1.5.0

### DIFF
--- a/lib/rule.js
+++ b/lib/rule.js
@@ -1,9 +1,6 @@
 /* jshint node: true */
 'use strict';
 
-var RTM_EVENTS = require('slack-client/lib/clients/rtm/events/rtm-events');
-var REACTION_ADDED = RTM_EVENTS.EVENTS.REACTION_ADDED;
-
 module.exports = Rule;
 
 function Rule(configRule) {
@@ -21,7 +18,8 @@ Rule.prototype.match = function(message, slackClient) {
 };
 
 Rule.prototype.reactionMatches = function(message) {
-  return message.type === REACTION_ADDED && message.name === this.reactionName;
+  return (message.type === 'reaction_added' &&
+    message.name === this.reactionName);
 };
 
 Rule.prototype.issueAlreadyFiled = function(message) {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "main": "index.js",
   "dependencies": {
     "github": "^0.2.4",
-    "slack-client": "l12s/node-slack-client#fac6b9659a0b82a5b302ba3a972e66cae983af57"
+    "slack-client": "^1.5.0"
   },
   "peerDependencies": {
-    "hubot": "2.x"
+    "hubot": "2.x",
+    "hubot-slack": "3.x"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/test/rule-test.js
+++ b/test/rule-test.js
@@ -5,8 +5,6 @@
 'use strict';
 
 var Rule = require('../lib/rule');
-var RTM_EVENTS = require('slack-client/lib/clients/rtm/events/rtm-events');
-var REACTION_ADDED = RTM_EVENTS.EVENTS.REACTION_ADDED;
 var chai = require('chai');
 
 var expect = chai.expect;
@@ -25,7 +23,7 @@ function newConfigRule() {
 
 function newReactionAddedMessage() {
   return {
-    type: REACTION_ADDED,
+    type: 'reaction_added',
     user: USER_ID,
     name: 'smiley',
     item: {
@@ -82,7 +80,7 @@ describe('Rule', function() {
     var rule = new Rule(newConfigRule()),
         message = newReactionAddedMessage(),
         client = new FakeSlackClient('hub');
-    message.type = RTM_EVENTS.EVENTS.HELLO;
+    message.type = 'hello';
     expect(rule.match(message, client)).to.be.false;
     expect(client.channelId).to.be.undefined;
   });


### PR DESCRIPTION
Though the 2.0 rewrite is underway in [l12s/node-slack-client](https://github.com/l12s/node-slack-client/), a more viable short-term workaround may be to fork [slackhq/hubot-slack](https://github.com/slackhq/hubot-slack/) and [slackhq/node-slack-client](https://github.com/slackhq/node-slack-client) and update those to send through [`response_added`](https://api.slack.com/events/reaction_added) messages.

cc: @ccostino @jeremiak @afeld 

(BTW, @afeld, anyone else in 18F/18f-bot land I should ping on any PRs?)