### PR TITLE
Introduce SlackClient abstraction

### DIFF
--- a/lib/rule.js
+++ b/lib/rule.js
@@ -1,6 +1,8 @@
 /* jshint node: true */
 'use strict';
 
+var SlackClient = require('./slack-client');
+
 module.exports = Rule;
 
 function Rule(configRule) {
@@ -18,7 +20,7 @@ Rule.prototype.match = function(message, slackClient) {
 };
 
 Rule.prototype.reactionMatches = function(message) {
-  return (message.type === 'reaction_added' &&
+  return (message.type === SlackClient.REACTION_ADDED &&
     message.name === this.reactionName);
 };
 
@@ -37,7 +39,7 @@ Rule.prototype.channelMatches = function(message, slackClient) {
   var channel;
 
   if (this.channelName) {
-    channel = slackClient.getChannelByID(message.item.channel);
+    channel = slackClient.getChannelName(message.item.channel);
   }
   return channel === this.channelName;
 };

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -1,0 +1,18 @@
+/* jshint node: true */
+'use strict';
+
+module.exports = SlackClient;
+
+// This client is for 18F-hacked versions of hubot-slack v1.5.0 and
+// slack-client v3.4.2.
+function SlackClient(robotSlackClient) {
+  this.client = robotSlackClient;
+}
+
+// From: https://api.slack.com/events/reaction_added
+// May get this directly from a future version of the slack-client package.
+SlackClient.REACTION_ADDED = 'reaction_added';
+
+SlackClient.prototype.getChannelName = function(channelId) {
+  return this.client.getChannelByID(channelId).name;
+};

--- a/test/rule-test.js
+++ b/test/rule-test.js
@@ -5,6 +5,7 @@
 'use strict';
 
 var Rule = require('../lib/rule');
+var SlackClient = require('../lib/slack-client');
 var chai = require('chai');
 
 var expect = chai.expect;
@@ -23,7 +24,7 @@ function newConfigRule() {
 
 function newReactionAddedMessage() {
   return {
-    type: 'reaction_added',
+    type: SlackClient.REACTION_ADDED,
     user: USER_ID,
     name: 'smiley',
     item: {
@@ -49,7 +50,7 @@ function FakeSlackClient(channelName) {
 
 FakeSlackClient.prototype.getChannelByID = function(channelId) {
   this.channelId = channelId;
-  return this.channelName;
+  return { name: this.channelName };
 };
 
 describe('Rule', function() {
@@ -63,7 +64,7 @@ describe('Rule', function() {
     var rule = new Rule(newConfigRule()),
         message = newReactionAddedMessage(),
         client = new FakeSlackClient('hub');
-    expect(rule.match(message, client)).to.be.true;
+    expect(rule.match(message, new SlackClient(client))).to.be.true;
     expect(client.channelId).to.eql(CHANNEL_ID);
   });
 
@@ -72,7 +73,7 @@ describe('Rule', function() {
         message = newReactionAddedMessage(),
         client = new FakeSlackClient('not-the-hub');
     delete rule.channelName;
-    expect(rule.match(message, client)).to.be.true;
+    expect(rule.match(message, new SlackClient(client))).to.be.true;
     expect(client.channelId).to.be.undefined;
   });
 
@@ -90,7 +91,7 @@ describe('Rule', function() {
         message = newReactionAddedMessage(),
         client = new FakeSlackClient('hub');
     message.name = 'sad-face';
-    expect(rule.match(message, client)).to.be.false;
+    expect(rule.match(message, new SlackClient(client))).to.be.false;
     expect(client.channelId).to.be.undefined;
   });
 
@@ -99,7 +100,7 @@ describe('Rule', function() {
         message = newReactionAddedMessage(),
         client = new FakeSlackClient('hub');
     message.item.message.reactions[0].count = 2;
-    expect(rule.match(message, client)).to.be.false;
+    expect(rule.match(message, new SlackClient(client))).to.be.false;
     expect(client.channelId).to.be.undefined;
   });
 
@@ -108,7 +109,7 @@ describe('Rule', function() {
         message = newReactionAddedMessage(),
         client = new FakeSlackClient('hub');
     message.item.message.reactions.pop();
-    expect(rule.match(message, client)).to.be.false;
+    expect(rule.match(message, new SlackClient(client))).to.be.false;
     expect(client.channelId).to.be.undefined;
   });
 
@@ -116,7 +117,7 @@ describe('Rule', function() {
     var rule = new Rule(newConfigRule()),
         message = newReactionAddedMessage(),
         client = new FakeSlackClient('not-the-hub');
-    expect(rule.match(message, client)).to.be.false;
+    expect(rule.match(message, new SlackClient(client))).to.be.false;
     expect(client.channelId).to.eql(CHANNEL_ID);
   });
 });


### PR DESCRIPTION
Should make migrating to [slack-client](https://www.npmjs.com/package/slack-client) v2.x and the corresponding [hubot-slack](https://www.npmjs.com/package/hubot-slack) modules easier when the time comes.

cc: @ccostino @jeremiak @afeld