### PR TITLE
Match hubot, hubot-slack, slack-client interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .*.swp
 coverage/*
 node_modules/
+.hubot_history

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,7 @@ var gulp = require('gulp');
 var yargs = require('yargs');
 var mocha = require('gulp-mocha');
 var jshint = require('gulp-jshint');
+require('coffee-script/register');
 
 function buildArgs(args) {
   var argName, skipArgs = { _: true, '$0': true };

--- a/lib/github-client.js
+++ b/lib/github-client.js
@@ -24,8 +24,8 @@ function createGitHubApi(config) {
   return api;
 }
 
-GitHubClient.prototype.fileNewIssue = function(metadata, repository, message) {
-  var issueBody = 'From ' + metadata.url + ':\n\n' + message.text,
+GitHubClient.prototype.fileNewIssue = function(metadata, repository, text) {
+  var issueBody = 'From ' + metadata.url + ':\n\n' + text,
       params = {
         user: this.user,
         repo: repository,

--- a/package.json
+++ b/package.json
@@ -14,9 +14,12 @@
   "devDependencies": {
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",
+    "coffee-script": "^1.10.0",
     "gulp": "^3.9.0",
     "gulp-jshint": "^2.0.0",
     "gulp-mocha": "^2.2.0",
+    "hubot": "^2.17.0",
+    "hubot-slack": "^3.4.2",
     "jshint": "^2.8.0",
     "mocha": "^2.3.4",
     "yargs": "^3.31.0"

--- a/test/github-client-test.js
+++ b/test/github-client-test.js
@@ -31,7 +31,7 @@ describe('GitHubClient', function() {
         api = new FakeGitHubApi(issueUrl, null, helpers.githubParams()),
         client = new GitHubClient(config, api);
     return client.fileNewIssue(
-      helpers.metadata(), 'handbook', helpers.message())
+      helpers.metadata(), 'handbook', helpers.targetMessage().text)
       .should.eventually.equal(issueUrl);
   });
 
@@ -40,7 +40,7 @@ describe('GitHubClient', function() {
         api = new FakeGitHubApi(null, errorMsg, helpers.githubParams()),
         client = new GitHubClient(config, api);
     return client.fileNewIssue(
-      helpers.metadata(), 'handbook', helpers.message())
+      helpers.metadata(), 'handbook', helpers.targetMessage().text)
       .should.be.rejectedWith(Error, errorMsg);
   });
 });

--- a/test/helpers/fake-slack-client.js
+++ b/test/helpers/fake-slack-client.js
@@ -2,6 +2,8 @@
 
 'use strict';
 
+var Channel = require('slack-client/src/channel');
+
 module.exports = FakeSlackClient;
 
 function FakeSlackClient(channelName) {
@@ -10,5 +12,7 @@ function FakeSlackClient(channelName) {
 
 FakeSlackClient.prototype.getChannelByID = function(channelId) {
   this.channelId = channelId;
-  return { name: this.channelName };
+  // https://api.slack.com/types/channel
+  return new Channel(this,
+    { id: channelId, name: this.channelName, 'is_channel': true });
 };

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -4,6 +4,8 @@
 
 var SlackClient = require('../../lib/slack-client');
 var testConfig = require('./test-config.json');
+var Hubot = require('hubot');
+var SlackBot = require('hubot-slack');
 
 exports = module.exports = {
   baseConfig: function() {
@@ -28,7 +30,12 @@ exports = module.exports = {
   CHANNEL_ID: 'C5150OU812',
 
   reactionAddedMessage: function() {
-    return {
+    var user, text, message;
+
+    user = new Hubot.User(exports.USER_ID,
+      { id: exports.USER_ID, name: 'mikebland', room: 'handbook' });
+    text = 'Hello, world!';
+    message = {
       type: SlackClient.REACTION_ADDED,
       user: exports.USER_ID,
       name: 'evergreen_tree',
@@ -36,6 +43,8 @@ exports = module.exports = {
         type: 'message',
         channel: exports.CHANNEL_ID,
         message: {
+          ts: '1360782804.083113',
+          text: text,
           reactions: [
             {
               name: 'evergreen_tree',
@@ -47,17 +56,22 @@ exports = module.exports = {
       },
       'event_ts': '1360782804.083113'
     };
+    return new SlackBot.SlackTextMessage(user, text, text, message);
   },
 
   metadata: function() {
     return {
-      url: 'https://18F.slack.com/archives/handbook/p1360782804083113',
-      title: 'Update from @mikebland in #handbook at 1360782804.083113'
+      domain: '18f',
+      channel: 'handbook',
+      user: 'mikebland',
+      timestamp: '1360782804.083113',
+      title: 'Update from @mikebland in #handbook at 1360782804.083113',
+      url: 'https://18f.slack.com/archives/handbook/p1360782804083113'
     };
   },
 
-  message: function() {
-    return { text: 'Hello, world!' };
+  targetMessage: function() {
+    return exports.reactionAddedMessage().rawMessage.item.message;
   },
 
   githubParams: function() {
@@ -66,7 +80,7 @@ exports = module.exports = {
       repo:  'handbook',
       title: exports.metadata().title,
       body:  'From ' + exports.metadata().url + ':\n\n' +
-        exports.message().text
+        exports.targetMessage().text
     };
   }
 };

--- a/test/rule-test.js
+++ b/test/rule-test.js
@@ -22,7 +22,7 @@ describe('Rule', function() {
 
   it('should match a channel-specific message', function() {
     var rule = new Rule(helpers.configRule()),
-        message = helpers.reactionAddedMessage(),
+        message = helpers.reactionAddedMessage().rawMessage,
         client = new FakeSlackClient('hub');
     expect(rule.match(message, new SlackClient(client))).to.be.true;
     expect(client.channelId).to.eql(helpers.CHANNEL_ID);
@@ -30,7 +30,7 @@ describe('Rule', function() {
 
   it('should match a non-channel-specific message', function() {
     var rule = new Rule(helpers.configRule()),
-        message = helpers.reactionAddedMessage(),
+        message = helpers.reactionAddedMessage().rawMessage,
         client = new FakeSlackClient('not-the-hub');
     delete rule.channelName;
     expect(rule.match(message, new SlackClient(client))).to.be.true;
@@ -48,7 +48,7 @@ describe('Rule', function() {
 
   it('should ignore a message if its name does not match', function() {
     var rule = new Rule(helpers.configRule()),
-        message = helpers.reactionAddedMessage(),
+        message = helpers.reactionAddedMessage().rawMessage,
         client = new FakeSlackClient('hub');
     message.name = 'sad-face';
     expect(rule.match(message, new SlackClient(client))).to.be.false;
@@ -57,7 +57,7 @@ describe('Rule', function() {
 
   it('should ignore a message if this is not the first reaction', function() {
     var rule = new Rule(helpers.configRule()),
-        message = helpers.reactionAddedMessage(),
+        message = helpers.reactionAddedMessage().rawMessage,
         client = new FakeSlackClient('hub');
     message.item.message.reactions[0].count = 2;
     expect(rule.match(message, new SlackClient(client))).to.be.false;
@@ -66,7 +66,7 @@ describe('Rule', function() {
 
   it('should ignore a message if the inner reaction isn\'t found', function() {
     var rule = new Rule(helpers.configRule()),
-        message = helpers.reactionAddedMessage(),
+        message = helpers.reactionAddedMessage().rawMessage,
         client = new FakeSlackClient('hub');
     message.item.message.reactions.pop();
     expect(rule.match(message, new SlackClient(client))).to.be.false;
@@ -75,7 +75,7 @@ describe('Rule', function() {
 
   it('should ignore a message if the channel doesn\'t match', function() {
     var rule = new Rule(helpers.configRule()),
-        message = helpers.reactionAddedMessage(),
+        message = helpers.reactionAddedMessage().rawMessage,
         client = new FakeSlackClient('not-the-hub');
     expect(rule.match(message, new SlackClient(client))).to.be.false;
     expect(client.channelId).to.eql(helpers.CHANNEL_ID);


### PR DESCRIPTION
Studying the [hubot](https://github.com/github/hubot), [hubot-slack](https://github.com/slackhq/hubot-slack), and [slack-client](https://github.com/slackhq/node-slack-client/) code further revealed some incorrect assumptions about the interface of their objects. This commit fixes these, and uses data objects from those packages in the tests.

cc: @ccostino @jeremiak 