### PR TITLE
Add Middleware package

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -59,8 +59,9 @@ Middleware.prototype.parseMetadata = function(message) {
     user: this.slackClient.getUserName(message.user),
     timestamp: message.item.message.ts
   };
+  result.date = new Date(result.timestamp * 1000);
   result.title = 'Update from @' + result.user + ' in #' + result.channel +
-    ' at ' + result.timestamp;
+    ' at ' + result.date.toUTCString();
   result.url = 'https://' + result.domain + '.slack.com/archives/' +
     result.channel + '/p' + result.timestamp.replace('.', '');
   return result;

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -37,7 +37,7 @@ Middleware.prototype.execute = function(context, next, done) {
   };
 
   return this.githubClient.fileNewIssue(this.parseMetadata(message),
-    rule.githubRepository, message.item.message.text)
+    rule.githubRepository, this.slackClient.getMessageText(response.message))
     .then(resolve, reject)
     .then(function() { next(done); });
 };

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,0 +1,67 @@
+/* jshint node: true */
+'use strict';
+
+var Rule = require('./rule');
+var SlackClient = require('./slack-client');
+
+module.exports = Middleware;
+
+function Middleware(configRules, slackClient, githubClient) {
+  this.rules = configRules.map(function(rule) {
+    return new Rule(rule);
+  });
+  this.slackClient = slackClient;
+  this.githubClient = githubClient;
+}
+
+Middleware.prototype.execute = function(context, next, done) {
+  var response = context.response,
+      message = response.message.rawMessage,
+      rule = this.findMatchingRule(message),
+      resolve,
+      reject,
+      that = this;
+
+  if (!rule) {
+    return next(done);
+  }
+
+  resolve = function(issueUrl) {
+    response.reply('created: ' + issueUrl);
+  };
+
+  reject = function(err) {
+    response.reply('failed to create a GitHub issue in ' +
+      that.githubClient.user + '/' + rule.githubRepository + ': ' +
+      err.message);
+  };
+
+  return this.githubClient.fileNewIssue(this.parseMetadata(message),
+    rule.githubRepository, message.item.message.text)
+    .then(resolve, reject)
+    .then(function() { next(done); });
+};
+
+Middleware.prototype.findMatchingRule = function(message) {
+  var slackClient = this.slackClient;
+
+  if (message && message.type === SlackClient.REACTION_ADDED) {
+    return this.rules.find(function(rule) {
+      return rule.match(message, slackClient);
+    });
+  }
+};
+
+Middleware.prototype.parseMetadata = function(message) {
+  var result = {
+    domain: this.slackClient.getTeamDomain(),
+    channel: this.slackClient.getChannelName(message.item.channel),
+    user: this.slackClient.getUserName(message.user),
+    timestamp: message.item.message.ts
+  };
+  result.title = 'Update from @' + result.user + ' in #' + result.channel +
+    ' at ' + result.timestamp;
+  result.url = 'https://' + result.domain + '.slack.com/archives/' +
+    result.channel + '/p' + result.timestamp.replace('.', '');
+  return result;
+};

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -1,8 +1,6 @@
 /* jshint node: true */
 'use strict';
 
-var SlackClient = require('./slack-client');
-
 module.exports = Rule;
 
 function Rule(configRule) {
@@ -13,6 +11,7 @@ function Rule(configRule) {
   }
 }
 
+// This expects just the rawMessage from a SlackTextMessage.
 Rule.prototype.match = function(message, slackClient) {
   return (this.reactionMatches(message) &&
     !this.issueAlreadyFiled(message) &&
@@ -20,8 +19,7 @@ Rule.prototype.match = function(message, slackClient) {
 };
 
 Rule.prototype.reactionMatches = function(message) {
-  return (message.type === SlackClient.REACTION_ADDED &&
-    message.name === this.reactionName);
+  return message.name === this.reactionName;
 };
 
 Rule.prototype.issueAlreadyFiled = function(message) {

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -24,3 +24,7 @@ SlackClient.prototype.getTeamDomain = function() {
 SlackClient.prototype.getUserName = function(userId) {
   return this.client.getUserByID(userId).name;
 };
+
+SlackClient.prototype.getMessageText = function(message) {
+  return message.text;
+};

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -16,3 +16,11 @@ SlackClient.REACTION_ADDED = 'reaction_added';
 SlackClient.prototype.getChannelName = function(channelId) {
   return this.client.getChannelByID(channelId).name;
 };
+
+SlackClient.prototype.getTeamDomain = function() {
+  return this.client.team.domain;
+};
+
+SlackClient.prototype.getUserName = function(userId) {
+  return this.client.getUserByID(userId).name;
+};

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "hubot-slack": "^3.4.2",
     "jshint": "^2.8.0",
     "mocha": "^2.3.4",
+    "sinon": "^1.17.2",
     "yargs": "^3.31.0"
   },
   "scripts": {

--- a/test/config-test.js
+++ b/test/config-test.js
@@ -77,7 +77,7 @@ describe('Config', function() {
       'unknown property foo',
       'unknown property bar',
       'rule 0 contains unknown property baz',
-      'rule 1 contains unknown property quux',
+      'rule 3 contains unknown property quux',
     ];
 
     expect(function() { new Config(config); }).to.throw(  // jshint ignore:line

--- a/test/github-client-test.js
+++ b/test/github-client-test.js
@@ -31,7 +31,7 @@ describe('GitHubClient', function() {
         api = new FakeGitHubApi(issueUrl, null, helpers.githubParams()),
         client = new GitHubClient(config, api);
     return client.fileNewIssue(
-      helpers.metadata(), 'handbook', helpers.targetMessage().text)
+      helpers.metadata(), 'handbook', helpers.reactionAddedMessage().text)
       .should.eventually.equal(issueUrl);
   });
 
@@ -40,7 +40,7 @@ describe('GitHubClient', function() {
         api = new FakeGitHubApi(null, errorMsg, helpers.githubParams()),
         client = new GitHubClient(config, api);
     return client.fileNewIssue(
-      helpers.metadata(), 'handbook', helpers.targetMessage().text)
+      helpers.metadata(), 'handbook', helpers.reactionAddedMessage().text)
       .should.be.rejectedWith(Error, errorMsg);
   });
 });

--- a/test/helpers/fake-slack-client.js
+++ b/test/helpers/fake-slack-client.js
@@ -3,11 +3,14 @@
 'use strict';
 
 var Channel = require('slack-client/src/channel');
+var Team = require('slack-client/src/team');
+var User = require('slack-client/src/user');
 
 module.exports = FakeSlackClient;
 
 function FakeSlackClient(channelName) {
   this.channelName = channelName;
+  this.team = new Team(this, '18F', '18F', '18f');
 }
 
 FakeSlackClient.prototype.getChannelByID = function(channelId) {
@@ -15,4 +18,10 @@ FakeSlackClient.prototype.getChannelByID = function(channelId) {
   // https://api.slack.com/types/channel
   return new Channel(this,
     { id: channelId, name: this.channelName, 'is_channel': true });
+};
+
+FakeSlackClient.prototype.getUserByID = function(userId) {
+  this.userId = userId;
+  // https://api.slack.com/types/user
+  return new User(this, { id: userId, name: 'mikebland' });
 };

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -65,7 +65,9 @@ exports = module.exports = {
       channel: 'handbook',
       user: 'mikebland',
       timestamp: '1360782804.083113',
-      title: 'Update from @mikebland in #handbook at 1360782804.083113',
+      date: new Date(1360782804.083113 * 1000),
+      title: 'Update from @mikebland in #handbook at ' +
+        'Wed, 13 Feb 2013 19:13:24 GMT',
       url: 'https://18f.slack.com/archives/handbook/p1360782804083113'
     };
   },

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -72,17 +72,13 @@ exports = module.exports = {
     };
   },
 
-  targetMessage: function() {
-    return exports.reactionAddedMessage().rawMessage.item.message;
-  },
-
   githubParams: function() {
     return {
       user:  '18F',
       repo:  'handbook',
       title: exports.metadata().title,
       body:  'From ' + exports.metadata().url + ':\n\n' +
-        exports.targetMessage().text
+        exports.reactionAddedMessage().text
     };
   }
 };

--- a/test/helpers/test-config.json
+++ b/test/helpers/test-config.json
@@ -5,6 +5,17 @@
   "rules": [
     {
       "reactionName": "evergreen_tree",
+      "githubRepository": "hub",
+      "channelName": "hub"
+    },
+
+    {
+      "reactionName": "smiley",
+      "githubRepository": "hubot-slack-github-issues"
+    },
+
+    {
+      "reactionName": "evergreen_tree",
       "githubRepository": "handbook"
     }
   ]

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -1,0 +1,144 @@
+/* jshint node: true */
+/* jshint mocha: true */
+/* jshint expr: true */
+
+'use strict';
+
+var Middleware = require('../lib/middleware');
+var GitHubClient = require('../lib/github-client');
+var SlackClient = require('../lib/slack-client');
+var helpers = require('./helpers');
+var FakeSlackClient = require('./helpers/fake-slack-client');
+var sinon = require('sinon');
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+
+var expect = chai.expect;
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('Middleware', function() {
+  var rules, slackClient, githubClient, middleware;
+
+  beforeEach(function() {
+    rules = helpers.baseConfig().rules;
+    slackClient = new FakeSlackClient('handbook');
+    githubClient = new GitHubClient(helpers.baseConfig(), {});
+    middleware = new Middleware(
+      rules, new SlackClient(slackClient), githubClient);
+  });
+
+  describe('parseMetadata', function() {
+    it('should parse GitHub request metadata from a message', function() {
+      middleware.parseMetadata(helpers.reactionAddedMessage().rawMessage)
+        .should.eql(helpers.metadata());
+      slackClient.channelId.should.equal(helpers.CHANNEL_ID);
+      slackClient.userId.should.equal(helpers.USER_ID);
+    });
+  });
+
+  describe('findMatchingRule', function() {
+    it('should find the rule matching the message', function() {
+      var message = helpers.reactionAddedMessage().rawMessage,
+          expected = rules[rules.length - 1],
+          result = middleware.findMatchingRule(message);
+
+      result.reactionName.should.equal(expected.reactionName);
+      result.githubRepository.should.equal(expected.githubRepository);
+      result.should.not.have.property('channelName');
+    });
+
+    it('should ignore a message if it is undefined', function() {
+      // When execute() tries to pass context.response.message.rawMessage from
+      // a message that doesn't have one, the argument to findMatchingRule()
+      // will be undefined.
+      expect(middleware.findMatchingRule(undefined)).to.be.undefined;
+    });
+
+    it('should ignore a message if its type does not match', function() {
+      var message = helpers.reactionAddedMessage();
+      message.type = 'hello';
+      expect(middleware.findMatchingRule(message)).to.be.undefined;
+    });
+
+    it('should ignore messages that do not match', function() {
+      var message = helpers.reactionAddedMessage().rawMessage;
+      message.name = 'sad-face';
+      expect(middleware.findMatchingRule(message)).to.be.undefined;
+    });
+  });
+
+  describe('execute', function() {
+    var message, context, fileNewIssue, reply, next, hubotDone;
+    var metadata, expectedFileNewIssueArgs, result;
+
+    beforeEach(function() {
+      message = helpers.reactionAddedMessage();
+      context = {
+        response: {
+          message: message,
+          reply: sinon.spy()
+        }
+      };
+
+      fileNewIssue = sinon.stub(githubClient, 'fileNewIssue');
+      reply = context.response.reply;
+      next = sinon.spy();
+      hubotDone = sinon.spy();
+
+      metadata = helpers.metadata();
+      expectedFileNewIssueArgs = [metadata, 'handbook',
+        helpers.reactionAddedMessage().rawMessage.item.message.text];
+    });
+
+    it('should ignore messages that do not match', function() {
+      message.rawMessage.name = 'sad-face';
+      result = middleware.execute(context, next, hubotDone);
+      expect(result).to.be.undefined;
+      next.calledOnce.should.be.true;
+      next.calledWith(hubotDone).should.be.true;
+      hubotDone.called.should.be.false;
+      reply.called.should.be.false;
+      fileNewIssue.called.should.be.false;
+    });
+
+    it('should successfully parse a message and file an issue', function(done) {
+      fileNewIssue.returns(Promise.resolve(metadata.url));
+      result = middleware.execute(context, next, hubotDone);
+
+      if (!result) {
+        return done(new Error('middleware.execute did not return a Promise'));
+      }
+
+      result.should.be.fulfilled.then(function() {
+        fileNewIssue.calledOnce.should.be.true;
+        fileNewIssue.firstCall.args.should.eql(expectedFileNewIssueArgs);
+        reply.calledOnce.should.be.true;
+        reply.firstCall.args.should.eql(['created: ' + metadata.url]);
+        next.calledOnce.should.be.true;
+        next.calledWith(hubotDone).should.be.true;
+        hubotDone.called.should.be.false;
+      }).should.notify(done);
+    });
+
+    it('should parse a message but fail to file an issue', function(done) {
+      fileNewIssue.returns(Promise.reject(new Error('test failure')));
+      result = middleware.execute(context, next, hubotDone);
+
+      if (!result) {
+        return done(new Error('middleware.execute did not return a Promise'));
+      }
+
+      result.should.be.fulfilled.then(function() {
+        fileNewIssue.calledOnce.should.be.true;
+        fileNewIssue.firstCall.args.should.eql(expectedFileNewIssueArgs);
+        reply.calledOnce.should.be.true;
+        reply.firstCall.args.should.eql(
+          ['failed to create a GitHub issue in 18F/handbook: test failure']);
+        next.calledOnce.should.be.true;
+        next.calledWith(hubotDone).should.be.true;
+        hubotDone.called.should.be.false;
+      }).should.notify(done);
+    });
+  });
+});

--- a/test/rule-test.js
+++ b/test/rule-test.js
@@ -37,15 +37,6 @@ describe('Rule', function() {
     expect(client.channelId).to.be.undefined;
   });
 
-  it('should ignore a message if its type does not match', function() {
-    var rule = new Rule(helpers.configRule()),
-        message = helpers.reactionAddedMessage(),
-        client = new FakeSlackClient('hub');
-    message.type = 'hello';
-    expect(rule.match(message, client)).to.be.false;
-    expect(client.channelId).to.be.undefined;
-  });
-
   it('should ignore a message if its name does not match', function() {
     var rule = new Rule(helpers.configRule()),
         message = helpers.reactionAddedMessage().rawMessage,


### PR DESCRIPTION
This is the fourth object ported from the `work-in-progress` branch.

Notice that Middleware.findMatchingRule() will ignore non-reaction messages before checking rules. Consequently, the 'should ignore a message if its type does not match' test was moved from rule-test to middleware-test.

cc: @ccostino @jeremiak @afeld @andrewmaier @melodykramer @mtorres253 