### PR TITLE
Read GitHub token from HUBOT_GITHUB_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ npm install hubot-slack-github-issues --save
 You'll need to create a JSON file conforming to the following schema:
 
 * *githubUser*: GitHub organization or username owning all repositories
-* *githubToken*: GitHub API token
 * *githubTimeout*: GitHub API timeout limit in milliseconds
 * *rules*: defines each condition that will result in a new GitHub issue
   * *reactionName* name of the reaction emoji triggering the rule
@@ -42,7 +41,6 @@ For example:
 ```json
 {
   "githubUser": "18F",
-  "githubToken": "<18F-api-token>",
   "githubTimeout": 5000,
   "rules": [
     {
@@ -53,9 +51,12 @@ For example:
 }
 ```
 
-The path to this configuration file should be made available to the running
-Hubot instance via the `HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH` environment
-variable.
+The following environment variables must also be set:
+
+* `HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH`: the path to the configuration file
+* `HUBOT_GITHUB_TOKEN`: GitHub API token
+* `HUBOT_SLACK_TOKEN`: Slack API token (needed by
+  [`hubot-slack`](https://www.npmjs.com/package/hubot-slack))
 
 ## Public domain
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -19,7 +19,6 @@ function Config(configuration) {
 var schema = {
   requiredTopLevelFields: {
     githubUser: 'GitHub username',
-    githubToken: 'GitHub API token',
     githubTimeout: 'GitHub API timeout limit in milliseconds',
     rules: 'Slack-reaction-to-GitHub-issue rules'
   },

--- a/lib/github-client.js
+++ b/lib/github-client.js
@@ -19,7 +19,7 @@ function createGitHubApi(config) {
 
   api.authenticate({
     type: 'oauth',
-    token: config.githubToken
+    token: process.env.HUBOT_GITHUB_TOKEN
   });
   return api;
 }

--- a/test/config-test.js
+++ b/test/config-test.js
@@ -12,6 +12,15 @@ var expect = chai.expect;
 chai.should();
 
 describe('Config', function() {
+  before(function() {
+    process.env.HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH = path.join(
+      __dirname, 'helpers', 'test-config.json');
+  });
+
+  after(function() {
+    delete process.env.HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH;
+  });
+
   it('should validate the base config', function() {
     var baseConfig = helpers.baseConfig(),
         config = new Config(baseConfig);
@@ -35,7 +44,6 @@ describe('Config', function() {
   it('should raise errors for missing required fields', function() {
     var errors = [
       'missing githubUser',
-      'missing githubToken',
       'missing githubTimeout',
       'missing rules'
     ];
@@ -85,10 +93,8 @@ describe('Config', function() {
   });
 
   it('should load from HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH', function() {
-    var testConfigPath = path.join(__dirname, 'helpers', 'test-config.json'),
-        baseConfig = helpers.baseConfig();
-    process.env.HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH = testConfigPath;
-    var config = new Config();
+    var baseConfig = helpers.baseConfig(),
+        config = new Config();
     expect(JSON.stringify(config)).to.eql(JSON.stringify(baseConfig));
   });
 });

--- a/test/github-client-test.js
+++ b/test/github-client-test.js
@@ -16,14 +16,23 @@ chai.use(chaiAsPromised);
 describe('GitHubClient', function() {
   var config = helpers.baseConfig();
 
+  before(function() {
+    process.env.HUBOT_GITHUB_TOKEN = '<18F-github-token>';
+  });
+
+  after(function() {
+    delete process.env.HUBOT_GITHUB_TOKEN;
+  });
+
   it('should create a githubApiClient from the configuration', function() {
     var client = new GitHubClient(config);
+
     expect(client).to.have.property('user', config.githubUser);
     expect(client.api).to.have.deep.property(
       'config.timeout', config.githubTimeout);
     expect(client.api).to.have.deep.property('auth.type', 'oauth');
     expect(client.api).to.have.deep.property(
-      'auth.token', config.githubToken);
+      'auth.token', process.env.HUBOT_GITHUB_TOKEN);
   });
 
   it('should successfully file an issue', function() {

--- a/test/helpers/test-config.json
+++ b/test/helpers/test-config.json
@@ -1,6 +1,5 @@
 {
   "githubUser": "18F",
-  "githubToken": "<18F-api-token>",
   "githubTimeout": 5000,
   "rules": [
     {


### PR DESCRIPTION
This appears to be the preferred method of passing authentication secrets to Hubot, so that the rest of the configuration can be stored in version control.

Also updates config-test.js to hoist HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH into before() and to tear it down in after().

cc: @ccostino @jeremiak @afeld 