### PR TITLE
Add .js ext to load scripts/slack-github-issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,5 +6,5 @@ var log = require('./lib/log');
 
 module.exports = function(robot) {
   log('loading');
-  robot.loadFile(path.resolve(__dirname, 'scripts'), 'slack-github-issues');
+  robot.loadFile(path.resolve(__dirname, 'scripts'), 'slack-github-issues.js');
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-slack-github-issues",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Hubot script using the Slack Real Time Messaging API to file GitHub issues",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
This is why Hubot wasn't finding the script. `robot.loadFile` will only try to load the file if it has an extension in `require.extensions`.

Going to merge myself, since this really is a facepalm.

cc: @afeld @ccostino 