### PR TITLE
Prepare for fetching and adding reactions

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -18,33 +18,13 @@ function Middleware(configRules, slackClient, githubClient) {
 Middleware.prototype.execute = function(context, next, done) {
   var response = context.response,
       message = response.message.rawMessage,
-      rule = this.findMatchingRule(message),
-      metadata,
-      resolve,
-      reject,
-      that = this;
+      rule = this.findMatchingRule(message);
 
   if (!rule) {
     return next(done);
   }
 
-  resolve = function(issueUrl) {
-    log('GitHub success: ' + issueUrl);
-    response.reply('created: ' + issueUrl);
-  };
-
-  reject = function(err) {
-    log('GitHub error: ' + err.message);
-    response.reply('failed to create a GitHub issue in ' +
-      that.githubClient.user + '/' + rule.githubRepository + ': ' +
-      err.message);
-  };
-
-  metadata = this.parseMetadata(message);
-  log('making GitHub request for ' + metadata.url);
-  return this.githubClient.fileNewIssue(metadata,
-    rule.githubRepository, this.slackClient.getMessageText(response.message))
-    .then(resolve, reject)
+  return fileGitHubIssue(this, message, rule, response)
     .then(function() { next(done); });
 };
 
@@ -72,3 +52,25 @@ Middleware.prototype.parseMetadata = function(message) {
     result.channel + '/p' + result.timestamp.replace('.', '');
   return result;
 };
+
+function fileGitHubIssue(that, message, rule, response) {
+  var metadata = that.parseMetadata(message),
+      resolve, reject;
+
+  resolve = function(issueUrl) {
+    log('GitHub success: ' + issueUrl);
+    response.reply('created: ' + issueUrl);
+  };
+
+  reject = function(err) {
+    log('GitHub error: ' + err.message);
+    response.reply('failed to create a GitHub issue in ' +
+      that.githubClient.user + '/' + rule.githubRepository + ': ' +
+      err.message);
+  };
+
+  log('making GitHub request for ' + metadata.url);
+  return that.githubClient.fileNewIssue(metadata,
+    rule.githubRepository, that.slackClient.getMessageText(response.message))
+    .then(resolve, reject);
+}


### PR DESCRIPTION
This hoists the message type check from `Middleware.findMatchingRule` to `Middleware.execute`, then extracts `fileGitHubIssue` into its own function. This is to prepare for adding extra steps into the algorithm to make additional Slack API calls per #17.

cc: @ccostino @afeld @jeremiak 