### PR TITLE
Add makeApiCall, getReactions to SlackClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For example:
 The following environment variables must also be set:
 
 * `HUBOT_GITHUB_TOKEN`: GitHub API token
-* `HUBOT_SLACK_TOKEN`: Slack API token (needed by
+* `HUBOT_SLACK_TOKEN`: Slack API token (also needed by
   [`hubot-slack`](https://www.npmjs.com/package/hubot-slack))
 
 The following environment variables are optional:

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -29,50 +29,6 @@ SlackClient.prototype.getUserName = function(userId) {
   return this.client.getUserByID(userId).name;
 };
 
-function makeApiCall(that, method, postData) {
-  return new Promise(function(resolve, reject) {
-    var postDataString, options, req;
-
-    postData.token = process.env.HUBOT_SLACK_TOKEN;
-    postDataString = JSON.stringify(postData);
-
-    options = {
-      protocol: that.protocol,
-      host: that.host,
-      port: that.port,
-      path: '/api/' + method,
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': postDataString.length
-      }
-    };
-
-    req = http.request(options, function(res) {
-      var result = '';
-
-      res.setEncoding('utf8');
-      res.on('data', function(chunk) {
-        result = result + chunk;
-      });
-      res.on('end', function() {
-        if (res.statusCode >=200 && res.statusCode <= 300) {
-          resolve(result);
-        } else {
-          reject(new Error('received ' + res.statusCode +
-            ' response from Slack API: ' + result));
-        }
-      });
-    });
-
-    req.on('error', function(err) {
-      reject(new Error('failed to make Slack API request: ' + err.message));
-    });
-    req.write(postDataString);
-    req.end();
-  });
-}
-
 SlackClient.prototype.getMessageText = function(message) {
   return message.text;
 };
@@ -81,3 +37,51 @@ SlackClient.prototype.getReactions = function(channel, timestamp) {
   return makeApiCall(this, 'reactions.get',
     { channel: channel, timestamp: timestamp });
 };
+
+function makeApiCall(that, method, params) {
+  return new Promise(function(resolve, reject) {
+    var paramsStr, req;
+
+    params.token = process.env.HUBOT_SLACK_TOKEN;
+    paramsStr = JSON.stringify(params);
+
+    req = http.request(getHttpOptions(that, method, paramsStr), function(res) {
+      handleResponse(res, resolve, reject);
+    });
+    req.on('error', function(err) {
+      reject(new Error('failed to make Slack API request: ' + err.message));
+    });
+    req.end(paramsStr);
+  });
+}
+
+function getHttpOptions(that, method, postDataString) {
+  return {
+    protocol: that.protocol,
+    host: that.host,
+    port: that.port,
+    path: '/api/' + method,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': postDataString.length
+    }
+  };
+}
+
+function handleResponse(res, resolve, reject) {
+  var result = '';
+
+  res.setEncoding('utf8');
+  res.on('data', function(chunk) {
+    result = result + chunk;
+  });
+  res.on('end', function() {
+    if (res.statusCode >=200 && res.statusCode <= 300) {
+      resolve(result);
+    } else {
+      reject(new Error('received ' + res.statusCode +
+        ' response from Slack API: ' + result));
+    }
+  });
+}

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -56,7 +56,7 @@ function makeApiCall(that, method, postData) {
         result = result + chunk;
       });
       res.on('end', function() {
-        if (res.statusCode >=200 && res.statusCode <= 400) {
+        if (res.statusCode >=200 && res.statusCode <= 300) {
           resolve(result);
         } else {
           reject(new Error('received ' + res.statusCode +

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -1,12 +1,16 @@
 /* jshint node: true */
 'use strict';
 
+var http = require('http');
+
 module.exports = SlackClient;
 
 // This client is for 18F-hacked versions of hubot-slack v1.5.0 and
 // slack-client v3.4.2.
 function SlackClient(robotSlackClient) {
   this.client = robotSlackClient;
+  this.protocol = 'https:';
+  this.host = 'slack.com';
 }
 
 // From: https://api.slack.com/events/reaction_added
@@ -25,6 +29,55 @@ SlackClient.prototype.getUserName = function(userId) {
   return this.client.getUserByID(userId).name;
 };
 
+function makeApiCall(that, method, postData) {
+  return new Promise(function(resolve, reject) {
+    var postDataString, options, req;
+
+    postData.token = process.env.HUBOT_SLACK_TOKEN;
+    postDataString = JSON.stringify(postData);
+
+    options = {
+      protocol: that.protocol,
+      host: that.host,
+      port: that.port,
+      path: '/api/' + method,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': postDataString.length
+      }
+    };
+
+    req = http.request(options, function(res) {
+      var result = '';
+
+      res.setEncoding('utf8');
+      res.on('data', function(chunk) {
+        result = result + chunk;
+      });
+      res.on('end', function() {
+        if (res.statusCode >=200 && res.statusCode <= 400) {
+          resolve(result);
+        } else {
+          reject(new Error('received ' + res.statusCode +
+            ' response from Slack API: ' + result));
+        }
+      });
+    });
+
+    req.on('error', function(err) {
+      reject(new Error('failed to make Slack API request: ' + err.message));
+    });
+    req.write(postDataString);
+    req.end();
+  });
+}
+
 SlackClient.prototype.getMessageText = function(message) {
   return message.text;
+};
+
+SlackClient.prototype.getReactions = function(channel, timestamp) {
+  return makeApiCall(this, 'reactions.get',
+    { channel: channel, timestamp: timestamp });
 };

--- a/test/helpers/fake-slack-api-server.js
+++ b/test/helpers/fake-slack-api-server.js
@@ -1,0 +1,36 @@
+/* jshint node: true */
+
+var http = require('http');
+
+module.exports = {
+  launch: function launch(expectedUrl, expectedParams, statusCode, payload) {
+    var server = new http.Server(function(req, res) {
+      var postBody = '', expectedBody, actualBody;
+
+      if (req.url !== expectedUrl) {
+        res.statusCode = 500;
+        res.end('expected URL ' + expectedUrl + ', actual URL ' + req.url);
+        return;
+      }
+
+      req.on('data', function(chunk) {
+        postBody = postBody + chunk.toString();
+      });
+
+      req.on('end', function() {
+        expectedBody = JSON.stringify(expectedParams);
+        actualBody = JSON.stringify(JSON.parse(postBody));
+
+        if (actualBody !== expectedBody) {
+          statusCode = 500;
+          payload = 'expected body ' + expectedBody +
+            ', actual body ' + actualBody;
+        }
+        res.statusCode = statusCode;
+        res.end(payload);
+      });
+    });
+    server.listen(0);
+    return server;
+  }
+};

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -28,6 +28,7 @@ exports = module.exports = {
 
   USER_ID: 'U5150OU812',
   CHANNEL_ID: 'C5150OU812',
+  TIMESTAMP: '1360782804.083113',
 
   reactionAddedMessage: function() {
     var user, text, message;
@@ -43,7 +44,7 @@ exports = module.exports = {
         type: 'message',
         channel: exports.CHANNEL_ID,
         message: {
-          ts: '1360782804.083113',
+          ts: exports.TIMESTAMP,
           text: text,
           reactions: [
             {
@@ -54,7 +55,7 @@ exports = module.exports = {
           ]
         }
       },
-      'event_ts': '1360782804.083113'
+      'event_ts': exports.TIMESTAMP
     };
     return new SlackBot.SlackTextMessage(user, text, text, message);
   },
@@ -64,7 +65,7 @@ exports = module.exports = {
       domain: '18f',
       channel: 'handbook',
       user: 'mikebland',
-      timestamp: '1360782804.083113',
+      timestamp: exports.TIMESTAMP,
       date: new Date(1360782804.083113 * 1000),
       title: 'Update from @mikebland in #handbook at ' +
         'Wed, 13 Feb 2013 19:13:24 GMT',

--- a/test/slack-client-test.js
+++ b/test/slack-client-test.js
@@ -1,0 +1,64 @@
+/* jshint node: true */
+/* jshint mocha: true */
+
+'use strict';
+
+var SlackClient = require('../lib/slack-client');
+var helpers = require('./helpers');
+var launchServer = require('./helpers/fake-slack-api-server').launch;
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('SlackClient', function() {
+  var slackToken, slackApiServer, slackClient, createServer;
+
+  before(function() {
+    slackClient = new SlackClient();
+    slackClient.protocol = 'http:';
+    slackClient.host = 'localhost';
+    slackToken = '<18F-slack-api-token>';
+    process.env.HUBOT_SLACK_TOKEN = slackToken;
+  });
+
+  after(function() {
+    delete process.env.HUBOT_SLACK_TOKEN;
+  });
+
+  beforeEach(function() {
+    slackApiServer = undefined;
+  });
+
+  afterEach(function() {
+    if (slackApiServer) {
+      slackApiServer.close();
+    }
+  });
+
+  createServer = function(expectedUrl, expectedParams, statusCode, payload) {
+    slackApiServer = launchServer(expectedUrl, expectedParams,
+      statusCode, payload);
+    slackClient.port = slackApiServer.address().port;
+  };
+
+  describe('getReactions', function() {
+    var payload, params;
+
+    beforeEach(function() {
+      payload = '{ "message": "Hello, world!" }';
+      params = {
+        channel: helpers.CHANNEL_ID,
+        timestamp: helpers.TIMESTAMP,
+        token: slackToken
+      };
+    });
+
+    it('should make a successful request', function() {
+      createServer('/api/reactions.get', params, 200, payload);
+      return slackClient.getReactions(helpers.CHANNEL_ID, helpers.TIMESTAMP)
+        .should.become(payload);
+    });
+  });
+});

--- a/test/slack-client-test.js
+++ b/test/slack-client-test.js
@@ -60,5 +60,18 @@ describe('SlackClient', function() {
       return slackClient.getReactions(helpers.CHANNEL_ID, helpers.TIMESTAMP)
         .should.become(payload);
     });
+
+    it('should fail to make a request if the server is down', function() {
+      return slackClient.getReactions(helpers.CHANNEL_ID, helpers.TIMESTAMP)
+        .should.be.rejectedWith('failed to make Slack API request:');
+    });
+
+    it('should make an unsuccessful request', function() {
+      // 300-family requests will currently fail as well.
+      createServer('/api/reactions.get', params, 404, 'Not found');
+      return slackClient.getReactions(helpers.CHANNEL_ID, helpers.TIMESTAMP)
+        .should.be.rejectedWith('received 404 response from Slack API: ' +
+          'Not found');
+    });
   });
 });

--- a/test/slack-client-test.js
+++ b/test/slack-client-test.js
@@ -13,7 +13,7 @@ chai.should();
 chai.use(chaiAsPromised);
 
 describe('SlackClient', function() {
-  var slackToken, slackApiServer, slackClient, createServer;
+  var slackToken, slackApiServer, slackClient, createServer, payload, params;
 
   before(function() {
     slackClient = new SlackClient();
@@ -21,6 +21,11 @@ describe('SlackClient', function() {
     slackClient.host = 'localhost';
     slackToken = '<18F-slack-api-token>';
     process.env.HUBOT_SLACK_TOKEN = slackToken;
+    params = {
+      channel: helpers.CHANNEL_ID,
+      timestamp: helpers.TIMESTAMP,
+      token: slackToken
+    };
   });
 
   after(function() {
@@ -29,6 +34,7 @@ describe('SlackClient', function() {
 
   beforeEach(function() {
     slackApiServer = undefined;
+    payload = '{ "message": "Hello, world!" }';
   });
 
   afterEach(function() {
@@ -44,17 +50,6 @@ describe('SlackClient', function() {
   };
 
   describe('getReactions', function() {
-    var payload, params;
-
-    beforeEach(function() {
-      payload = '{ "message": "Hello, world!" }';
-      params = {
-        channel: helpers.CHANNEL_ID,
-        timestamp: helpers.TIMESTAMP,
-        token: slackToken
-      };
-    });
-
     it('should make a successful request', function() {
       createServer('/api/reactions.get', params, 200, payload);
       return slackClient.getReactions(helpers.CHANNEL_ID, helpers.TIMESTAMP)


### PR DESCRIPTION
This implements and tests the Promise that will make the [reactions.get API call](https://api.slack.com/methods/reactions.get) per #17.

cc: @ccostino @afeld @jeremiak 