### PR TITLE
Remove inProgressReaction, add slackTimeout config, add SlackClient.addSuccessReaction()

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You'll need to create a JSON file conforming to the following schema:
 
 * *githubUser*: GitHub organization or username owning all repositories
 * *githubTimeout*: GitHub API timeout limit in milliseconds
-* *inProgressReaction*: emoji used to indicate an issue is being filed
+* *slackTimeout*: Slack API timeout limit in milliseconds
 * *successReaction* emoji used to indicate an issue was successfully filed
 * *rules*: defines each condition that will result in a new GitHub issue
   * *reactionName* name of the reaction emoji triggering the rule

--- a/config/slack-github-issues.json
+++ b/config/slack-github-issues.json
@@ -1,7 +1,7 @@
 {
   "githubUser": "18F",
   "githubTimeout": 5000,
-  "inProgressReaction": "checkered_flag",
+  "slackTimeout": 5000,
   "successReaction": "heavy_check_mark",
   "rules": [
     {

--- a/lib/config.js
+++ b/lib/config.js
@@ -21,7 +21,7 @@ var schema = {
   requiredTopLevelFields: {
     githubUser: 'GitHub username',
     githubTimeout: 'GitHub API timeout limit in milliseconds',
-    inProgressReaction: 'emoji used to indicate an issue is being filed',
+    slackTimeout: 'Slack API timeout limit in milliseconds',
     successReaction: 'emoji used to indicate an issue was successfully filed',
     rules: 'Slack-reaction-to-GitHub-issue rules'
   },

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -40,6 +40,11 @@ SlackClient.prototype.getReactions = function(channel, timestamp) {
     { channel: channel, timestamp: timestamp });
 };
 
+SlackClient.prototype.addSuccessReaction = function(channel, timestamp) {
+  return makeApiCall(this, 'reactions.add',
+    { channel: channel, timestamp: timestamp, name: this.successReaction });
+};
+
 function makeApiCall(that, method, params) {
   return new Promise(function(resolve, reject) {
     var paramsStr, req;

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -7,8 +7,10 @@ module.exports = SlackClient;
 
 // This client is for 18F-hacked versions of hubot-slack v1.5.0 and
 // slack-client v3.4.2.
-function SlackClient(robotSlackClient) {
+function SlackClient(robotSlackClient, config) {
   this.client = robotSlackClient;
+  this.timeout = config.slackTimeout;
+  this.successReaction = config.successReaction;
   this.protocol = 'https:';
   this.host = 'slack.com';
 }
@@ -48,6 +50,7 @@ function makeApiCall(that, method, params) {
     req = http.request(getHttpOptions(that, method, paramsStr), function(res) {
       handleResponse(res, resolve, reject);
     });
+    req.setTimeout(that.timeout);
     req.on('error', function(err) {
       reject(new Error('failed to make Slack API request: ' + err.message));
     });

--- a/scripts/slack-github-issues.js
+++ b/scripts/slack-github-issues.js
@@ -24,7 +24,7 @@ module.exports = function(robot) {
   var config = new Config(),
       impl = new Middleware(
         config.rules,
-        new SlackClient(robot.adapter.client),
+        new SlackClient(robot.adapter.client, config),
         new GitHubClient(config)),
       middleware = function(context, next, done) {
         impl.execute(context, next, done);

--- a/test/config-test.js
+++ b/test/config-test.js
@@ -61,7 +61,7 @@ describe('Config', function() {
     var errors = [
           'missing githubUser',
           'missing githubTimeout',
-          'missing inProgressReaction',
+          'missing slackTimeout',
           'missing successReaction',
           'missing rules'
         ],

--- a/test/helpers/test-config.json
+++ b/test/helpers/test-config.json
@@ -1,7 +1,7 @@
 {
   "githubUser": "18F",
   "githubTimeout": 5000,
-  "inProgressReaction": "checkered_flag",
+  "slackTimeout": 5000,
   "successReaction": "heavy_check_mark",
   "rules": [
     {

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -22,7 +22,8 @@ chai.should();
 
 describe('Integration test', function() {
   var middlewareImpl = null,
-      slackClient = new SlackClient(new FakeSlackClient('handbook')),
+      slackClient = new SlackClient(
+       new FakeSlackClient('handbook'), testConfig),
       githubParams = helpers.githubParams(),
       logHelper, logMessages,
       configLogMessages, githubLogMessage;

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -9,6 +9,7 @@ var GitHubClient = require('../lib/github-client');
 var SlackClient = require('../lib/slack-client');
 var scriptName = require('../package.json').name;
 var helpers = require('./helpers');
+var config = require('./helpers/test-config.json');
 var FakeSlackClient = require('./helpers/fake-slack-client');
 var LogHelper = require('./helpers/log-helper');
 var sinon = require('sinon');
@@ -27,7 +28,7 @@ describe('Middleware', function() {
     slackClient = new FakeSlackClient('handbook');
     githubClient = new GitHubClient(helpers.baseConfig(), {});
     middleware = new Middleware(
-      rules, new SlackClient(slackClient), githubClient);
+      rules, new SlackClient(slackClient, config), githubClient);
   });
 
   describe('parseMetadata', function() {

--- a/test/rule-test.js
+++ b/test/rule-test.js
@@ -7,6 +7,7 @@
 var Rule = require('../lib/rule');
 var SlackClient = require('../lib/slack-client');
 var helpers = require('./helpers');
+var config = require('./helpers/test-config.json');
 var FakeSlackClient = require('./helpers/fake-slack-client');
 var chai = require('chai');
 
@@ -24,7 +25,7 @@ describe('Rule', function() {
     var rule = new Rule(helpers.configRule()),
         message = helpers.reactionAddedMessage().rawMessage,
         client = new FakeSlackClient('hub');
-    expect(rule.match(message, new SlackClient(client))).to.be.true;
+    expect(rule.match(message, new SlackClient(client, config))).to.be.true;
     expect(client.channelId).to.eql(helpers.CHANNEL_ID);
   });
 
@@ -33,7 +34,7 @@ describe('Rule', function() {
         message = helpers.reactionAddedMessage().rawMessage,
         client = new FakeSlackClient('not-the-hub');
     delete rule.channelName;
-    expect(rule.match(message, new SlackClient(client))).to.be.true;
+    expect(rule.match(message, new SlackClient(client, config))).to.be.true;
     expect(client.channelId).to.be.undefined;
   });
 
@@ -42,7 +43,7 @@ describe('Rule', function() {
         message = helpers.reactionAddedMessage().rawMessage,
         client = new FakeSlackClient('hub');
     message.name = 'sad-face';
-    expect(rule.match(message, new SlackClient(client))).to.be.false;
+    expect(rule.match(message, new SlackClient(client, config))).to.be.false;
     expect(client.channelId).to.be.undefined;
   });
 
@@ -51,7 +52,7 @@ describe('Rule', function() {
         message = helpers.reactionAddedMessage().rawMessage,
         client = new FakeSlackClient('hub');
     message.item.message.reactions[0].count = 2;
-    expect(rule.match(message, new SlackClient(client))).to.be.false;
+    expect(rule.match(message, new SlackClient(client, config))).to.be.false;
     expect(client.channelId).to.be.undefined;
   });
 
@@ -60,7 +61,7 @@ describe('Rule', function() {
         message = helpers.reactionAddedMessage().rawMessage,
         client = new FakeSlackClient('hub');
     message.item.message.reactions.pop();
-    expect(rule.match(message, new SlackClient(client))).to.be.false;
+    expect(rule.match(message, new SlackClient(client, config))).to.be.false;
     expect(client.channelId).to.be.undefined;
   });
 
@@ -68,7 +69,7 @@ describe('Rule', function() {
     var rule = new Rule(helpers.configRule()),
         message = helpers.reactionAddedMessage().rawMessage,
         client = new FakeSlackClient('not-the-hub');
-    expect(rule.match(message, new SlackClient(client))).to.be.false;
+    expect(rule.match(message, new SlackClient(client, config))).to.be.false;
     expect(client.channelId).to.eql(helpers.CHANNEL_ID);
   });
 });

--- a/test/slack-client-test.js
+++ b/test/slack-client-test.js
@@ -16,7 +16,7 @@ describe('SlackClient', function() {
   var slackToken, slackApiServer, slackClient, createServer, payload, params;
 
   before(function() {
-    slackClient = new SlackClient();
+    slackClient = new SlackClient(undefined, helpers.baseConfig());
     slackClient.protocol = 'http:';
     slackClient.host = 'localhost';
     slackToken = '<18F-slack-api-token>';

--- a/test/slack-client-test.js
+++ b/test/slack-client-test.js
@@ -5,6 +5,7 @@
 
 var SlackClient = require('../lib/slack-client');
 var helpers = require('./helpers');
+var testConfig = require('./helpers/test-config.json');
 var launchServer = require('./helpers/fake-slack-api-server').launch;
 var chai = require('chai');
 var chaiAsPromised = require('chai-as-promised');
@@ -16,16 +17,11 @@ describe('SlackClient', function() {
   var slackToken, slackApiServer, slackClient, createServer, payload, params;
 
   before(function() {
-    slackClient = new SlackClient(undefined, helpers.baseConfig());
+    slackClient = new SlackClient(undefined, testConfig);
     slackClient.protocol = 'http:';
     slackClient.host = 'localhost';
     slackToken = '<18F-slack-api-token>';
     process.env.HUBOT_SLACK_TOKEN = slackToken;
-    params = {
-      channel: helpers.CHANNEL_ID,
-      timestamp: helpers.TIMESTAMP,
-      token: slackToken
-    };
   });
 
   after(function() {
@@ -50,6 +46,14 @@ describe('SlackClient', function() {
   };
 
   describe('getReactions', function() {
+    beforeEach(function() {
+      params = {
+        channel: helpers.CHANNEL_ID,
+        timestamp: helpers.TIMESTAMP,
+        token: slackToken
+      };
+    });
+
     it('should make a successful request', function() {
       createServer('/api/reactions.get', params, 200, payload);
       return slackClient.getReactions(helpers.CHANNEL_ID, helpers.TIMESTAMP)
@@ -67,6 +71,23 @@ describe('SlackClient', function() {
       return slackClient.getReactions(helpers.CHANNEL_ID, helpers.TIMESTAMP)
         .should.be.rejectedWith('received 404 response from Slack API: ' +
           'Not found');
+    });
+  });
+
+  describe('addSuccessReaction', function() {
+    beforeEach(function() {
+      params = {
+        channel: helpers.CHANNEL_ID,
+        timestamp: helpers.TIMESTAMP,
+        name: testConfig.successReaction,
+        token: slackToken
+      };
+    });
+
+    it('should make a successful request', function() {
+      createServer('/api/reactions.add', params, 200, payload);
+      return slackClient.addSuccessReaction(
+        helpers.CHANNEL_ID, helpers.TIMESTAMP).should.become(payload);
     });
   });
 });


### PR DESCRIPTION
The `slackTimeout` seems like a good thing to have. Both it and `successReaction` are passed into the SlackClient.

Removing `inProgressReaction` because, after thinking on it more, I realized that an in-memory object whose keys are message IDs (composed of the `channel:` and `timestamp:` members from the event message) should suffice.

More to come; trickling out these incremental PRs in the process.

cc: @ccostino @afeld @jeremiak 