### PR TITLE
Avoid multiple requests for a message, 1 of 3

### DIFF
--- a/lib/github-client.js
+++ b/lib/github-client.js
@@ -38,7 +38,7 @@ GitHubClient.prototype.fileNewIssue = function(metadata, repository) {
       if (err) {
         reject(err);
       } else {
-        resolve(data.url);
+        resolve(data.html_url);  // jshint ignore:line
       }
     });
   });

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -19,13 +19,16 @@ function Middleware(configRules, slackClient, githubClient) {
 Middleware.prototype.execute = function(context, next, done) {
   var response = context.response,
       message = response.message.rawMessage,
-      msgId = messageId(message),
       rule = this.findMatchingRule(message),
+      msgId,
       finish;
 
   if (!rule) {
     return next(done);
-  } else if (this.inProgress[msgId]) {
+  }
+
+  msgId = messageId(message);
+  if (this.inProgress[msgId]) {
     log(msgId + ': already in progress');
     return next(done);
   }

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -13,20 +13,34 @@ function Middleware(configRules, slackClient, githubClient) {
   });
   this.slackClient = slackClient;
   this.githubClient = githubClient;
+  this.inProgress = {};
 }
 
 Middleware.prototype.execute = function(context, next, done) {
   var response = context.response,
       message = response.message.rawMessage,
-      rule = this.findMatchingRule(message);
+      msgId = messageId(message),
+      rule = this.findMatchingRule(message),
+      finish;
 
   if (!rule) {
     return next(done);
+  } else if (this.inProgress[msgId]) {
+    log(msgId + ': already in progress');
+    return next(done);
   }
+  this.inProgress[msgId] = true;
 
+  finish = handleFinish(this, msgId, next, done);
   return fileGitHubIssue(this, message, rule, response)
-    .then(function() { next(done); });
+    .then(finish, finish);
 };
+
+function messageId(message) {
+  if (message) {
+    return message.item.channel + ':' + message.item.message.ts;
+  }
+}
 
 Middleware.prototype.findMatchingRule = function(message) {
   var slackClient = this.slackClient;
@@ -72,4 +86,14 @@ function fileGitHubIssue(that, message, rule, response) {
   log('making GitHub request for ' + metadata.url);
   return that.githubClient.fileNewIssue(metadata, rule.githubRepository)
     .then(resolve, reject);
+}
+
+function handleFinish(that, msgId, next, done) {
+  return function(err) {
+    if (err) {
+      log(err);
+    }
+    delete that.inProgress[msgId];
+    next(done);
+  };
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",
+    "chai-things": "^0.2.0",
     "coffee-script": "^1.10.0",
     "gulp": "^3.9.0",
     "gulp-jshint": "^2.0.0",

--- a/test/github-client-test.js
+++ b/test/github-client-test.js
@@ -36,11 +36,11 @@ describe('GitHubClient', function() {
   });
 
   it('should successfully file an issue', function() {
-    var issueUrl = 'https://github.com/18F/handbook/issues/1',
-        api = new FakeGitHubApi(issueUrl, null, helpers.githubParams()),
+    var api = new FakeGitHubApi(
+          helpers.ISSUE_URL, null, helpers.githubParams()),
         client = new GitHubClient(config, api);
     return client.fileNewIssue(helpers.metadata(), 'handbook')
-      .should.eventually.equal(issueUrl);
+      .should.eventually.equal(helpers.ISSUE_URL);
   });
 
   it('should receive an error when filing an issue', function() {

--- a/test/helpers/fake-github-api.js
+++ b/test/helpers/fake-github-api.js
@@ -17,7 +17,7 @@ function FakeGitHubApi(urlOnSuccess, msgOnError, expectedParams) {
             'actual:   ' + actualString
           ].join('\n  ')));
       } else if (urlOnSuccess) {
-        done(null, { url: urlOnSuccess });
+        done(null, { 'html_url': urlOnSuccess });
       } else {
         done(new Error(msgOnError));
       }

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -8,6 +8,14 @@ var Hubot = require('hubot');
 var SlackBot = require('hubot-slack');
 
 exports = module.exports = {
+  REACTION: 'evergreen_tree',
+  USER_ID: 'U5150OU812',
+  CHANNEL_ID: 'C5150OU812',
+  TIMESTAMP: '1360782804.083113',
+  MSG_ID: 'C5150OU812:1360782804.083113',
+  PERMALINK: 'https://18f.slack.com/archives/handbook/p1360782804083113',
+  ISSUE_URL: 'https://github.com/18F/handbook/issues/1',
+
   baseConfig: function() {
     // Notes on the `rules:` property:
     // - The first one matches the 'evergreen_tree' reaction from
@@ -20,15 +28,11 @@ exports = module.exports = {
 
   configRule: function() {
     return {
-      reactionName: 'evergreen_tree',
+      reactionName: exports.REACTION,
       githubRepository: 'hubot-slack-github-issues',
       channelName: 'hub'
     };
   },
-
-  USER_ID: 'U5150OU812',
-  CHANNEL_ID: 'C5150OU812',
-  TIMESTAMP: '1360782804.083113',
 
   reactionAddedMessage: function() {
     var user, text, message;
@@ -39,7 +43,7 @@ exports = module.exports = {
     message = {
       type: SlackClient.REACTION_ADDED,
       user: exports.USER_ID,
-      name: 'evergreen_tree',
+      name: exports.REACTION,
       item: {
         type: 'message',
         channel: exports.CHANNEL_ID,
@@ -48,7 +52,7 @@ exports = module.exports = {
           text: text,
           reactions: [
             {
-              name: 'evergreen_tree',
+              name: exports.REACTION,
               count: 1,
               users: [ exports.USER_ID ]
             }
@@ -69,7 +73,7 @@ exports = module.exports = {
       date: new Date(1360782804.083113 * 1000),
       title: 'Update from @mikebland in #handbook at ' +
         'Wed, 13 Feb 2013 19:13:24 GMT',
-      url: 'https://18f.slack.com/archives/handbook/p1360782804083113'
+      url: exports.PERMALINK
     };
   },
 

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -82,8 +82,7 @@ describe('Integration test', function() {
 
   context('an evergreen_tree reaction to a message', function() {
     beforeEach(function() {
-      var githubApi = new FakeGitHubApi(
-        helpers.metadata().url, '', githubParams);
+      var githubApi = new FakeGitHubApi(helpers.ISSUE_URL, '', githubParams);
 
       middlewareImpl.githubClient = new GitHubClient(testConfig, githubApi);
       return this.room.user.react('mikebland', 'evergreen_tree');
@@ -92,11 +91,11 @@ describe('Integration test', function() {
     it('should create a GitHub issue', function() {
       this.room.messages.should.eql([
         ['mikebland', 'evergreen_tree'],
-        ['hubot', '@mikebland created: ' + helpers.metadata().url]
+        ['hubot', '@mikebland created: ' + helpers.ISSUE_URL]
       ]);
       logMessages.should.eql(configLogMessages.concat([
         [githubLogMessage],
-        [scriptName + ': GitHub success: ' + helpers.metadata().url]
+        [scriptName + ': GitHub success: ' + helpers.ISSUE_URL]
       ]));
     });
   });

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -109,7 +109,7 @@ describe('Middleware', function() {
     });
 
     it('should successfully parse a message and file an issue', function(done) {
-      fileNewIssue.returns(Promise.resolve(metadata.url));
+      fileNewIssue.returns(Promise.resolve(helpers.ISSUE_URL));
       logHelper.captureLog();
       result = middleware.execute(context, next, hubotDone);
 
@@ -123,15 +123,13 @@ describe('Middleware', function() {
         fileNewIssue.calledOnce.should.be.true;
         fileNewIssue.firstCall.args.should.eql(expectedFileNewIssueArgs);
         reply.calledOnce.should.be.true;
-        reply.firstCall.args.should.eql(['created: ' + metadata.url]);
+        reply.firstCall.args.should.eql(['created: ' + helpers.ISSUE_URL]);
         next.calledOnce.should.be.true;
         next.calledWith(hubotDone).should.be.true;
         hubotDone.called.should.be.false;
         logHelper.messages.should.eql([
-          [scriptName + ': making GitHub request for ' +
-           'https://18f.slack.com/archives/handbook/p1360782804083113'],
-          [scriptName + ': GitHub success: ' +
-           'https://18f.slack.com/archives/handbook/p1360782804083113']
+          [scriptName + ': making GitHub request for ' + helpers.PERMALINK],
+          [scriptName + ': GitHub success: ' + helpers.ISSUE_URL]
         ]);
       }).should.notify(done);
     });
@@ -157,8 +155,7 @@ describe('Middleware', function() {
         next.calledWith(hubotDone).should.be.true;
         hubotDone.called.should.be.false;
         logHelper.messages.should.eql([
-          [scriptName + ': making GitHub request for ' +
-            'https://18f.slack.com/archives/handbook/p1360782804083113'],
+          [scriptName + ': making GitHub request for ' + helpers.PERMALINK],
           [scriptName + ': GitHub error: test failure']
         ]);
       }).should.notify(done);

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -15,10 +15,12 @@ var LogHelper = require('./helpers/log-helper');
 var sinon = require('sinon');
 var chai = require('chai');
 var chaiAsPromised = require('chai-as-promised');
+var chaiThings = require('chai-things');
 
 var expect = chai.expect;
 chai.should();
 chai.use(chaiAsPromised);
+chai.use(chaiThings);
 
 describe('Middleware', function() {
   var rules, slackClientImpl, githubClient, middleware;
@@ -173,6 +175,34 @@ describe('Middleware', function() {
           [scriptName + ': making GitHub request for ' + helpers.PERMALINK],
           [scriptName + ': GitHub error: test failure']
         ]);
+      }).should.notify(done);
+    });
+
+    it('should not file another issue for the same message when ' +
+      'one is in progress', function(done) {
+      fileNewIssue.returns(Promise.resolve(metadata.url));
+      result = doExecute(done);
+
+      if (!result) {
+        return;
+      }
+
+      if (middleware.execute(context, next, hubotDone) !== undefined) {
+        logHelper.restoreLog();
+        return done(new Error('middleware.execute did not prevent a second ' +
+          'issue being filed when one was in progress'));
+      }
+
+      return result.should.be.fulfilled.then(function() {
+        var inProgressLogMessage;
+
+        logHelper.restoreLog();
+        fileNewIssue.calledOnce.should.be.true;
+
+        inProgressLogMessage = [
+          scriptName + ': ' + helpers.MSG_ID + ': already in progress'];
+        logHelper.messages.should.include.something.that.deep.equals(
+          inProgressLogMessage);
       }).should.notify(done);
     });
   });

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -115,6 +115,20 @@ describe('Middleware', function() {
       }
     };
 
+    it('should ignore messages that are not reaction_added', function() {
+      message.rawMessage = { type: 'hello' };
+      logHelper.captureLog();
+      result = middleware.execute(context, next, hubotDone);
+      logHelper.restoreLog();
+      expect(result).to.be.undefined;
+      next.calledOnce.should.be.true;
+      next.calledWith(hubotDone).should.be.true;
+      hubotDone.called.should.be.false;
+      reply.called.should.be.false;
+      fileNewIssue.called.should.be.false;
+      logHelper.messages.should.be.empty;
+    });
+
     it('should ignore messages that do not match', function() {
       message.rawMessage.name = 'sad-face';
       logHelper.captureLog();

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -73,7 +73,7 @@ describe('Middleware', function() {
 
   describe('execute', function() {
     var message, context, fileNewIssue, reply, next, hubotDone,
-        metadata, expectedFileNewIssueArgs, result, logHelper;
+        metadata, expectedFileNewIssueArgs, result, logHelper, doExecute;
 
     beforeEach(function() {
       message = helpers.reactionAddedMessage();
@@ -94,6 +94,25 @@ describe('Middleware', function() {
       logHelper = new LogHelper();
     });
 
+    doExecute = function(done) {
+      var result;
+
+      try {
+        logHelper.captureLog();
+        result = middleware.execute(context, next, hubotDone);
+
+        if (!result) {
+          logHelper.restoreLog();
+          return done(new Error('middleware.execute did not return a Promise'));
+        }
+        return result;
+
+      } catch(err) {
+        logHelper.restoreLog();
+        throw err;
+      }
+    };
+
     it('should ignore messages that do not match', function() {
       message.rawMessage.name = 'sad-face';
       logHelper.captureLog();
@@ -110,12 +129,10 @@ describe('Middleware', function() {
 
     it('should successfully parse a message and file an issue', function(done) {
       fileNewIssue.returns(Promise.resolve(helpers.ISSUE_URL));
-      logHelper.captureLog();
-      result = middleware.execute(context, next, hubotDone);
+      result = doExecute(done);
 
       if (!result) {
-        logHelper.restoreLog();
-        return done(new Error('middleware.execute did not return a Promise'));
+        return;
       }
 
       result.should.be.fulfilled.then(function() {
@@ -136,12 +153,10 @@ describe('Middleware', function() {
 
     it('should parse a message but fail to file an issue', function(done) {
       fileNewIssue.returns(Promise.reject(new Error('test failure')));
-      logHelper.captureLog();
-      result = middleware.execute(context, next, hubotDone);
+      result = doExecute(done);
 
       if (!result) {
-        logHelper.restoreLog();
-        return done(new Error('middleware.execute did not return a Promise'));
+        return;
       }
 
       result.should.be.fulfilled.then(function() {


### PR DESCRIPTION
Part of #17. This prevents new Slack and GitHub requests from being filed when a message is currently being processed. The next requests will:

- stop processing messages with `config.successResponse`
- add `config.successResponse` to messages that have had GitHub issues
  successfully filed

cc: @afeld @ccostino @jeremiak 