### PR TITLE
Avoid multiple requests for a message, 2 of 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
 - "node"
 - "4.2"
+script: npm run lint && npm test && test/hubot-smoke-test.bash

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -40,6 +40,7 @@ Middleware.prototype.execute = function(context, next, done) {
   }
 
   this.inProgress[msgId] = true;
+  log(msgId + ': matches rule: ' + JSON.stringify(rule));
   finish = handleFinish(this, msgId, next, done);
 
   return fileGitHubIssue(this, msgId, message, rule.githubRepository, response)

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -81,15 +81,17 @@ function fileGitHubIssue(that, msgId, message, githubRepository, response) {
       resolve, reject;
 
   resolve = function(issueUrl) {
-    log(msgId + ': GitHub success: ' + issueUrl);
-    response.reply('created: ' + issueUrl);
+    var message = 'created: ' + issueUrl;
+    log(msgId + ': ' + message);
+    response.reply(message);
   };
 
   reject = function(err) {
-    log(msgId + ': GitHub error: ' + err.message);
-    response.reply('failed to create a GitHub issue in ' +
+    var message = 'failed to create a GitHub issue in ' +
       that.githubClient.user + '/' + githubRepository + ': ' +
-      err.message);
+      err.message;
+    log(msgId + ': ' + message);
+    response.reply(message);
   };
 
   log(msgId + ': making GitHub request for ' + metadata.url);

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -7,10 +7,11 @@ var log = require('./log');
 
 module.exports = Middleware;
 
-function Middleware(configRules, slackClient, githubClient) {
-  this.rules = configRules.map(function(rule) {
+function Middleware(config, slackClient, githubClient) {
+  this.rules = config.rules.map(function(rule) {
     return new Rule(rule);
   });
+  this.successReaction = config.successReaction;
   this.slackClient = slackClient;
   this.githubClient = githubClient;
   this.inProgress = {};
@@ -32,9 +33,15 @@ Middleware.prototype.execute = function(context, next, done) {
     log(msgId + ': already in progress');
     return next(done);
   }
-  this.inProgress[msgId] = true;
 
+  if (alreadyProcessed(message, this.successReaction)) {
+    log(msgId + ': already processed');
+    return next(done);
+  }
+
+  this.inProgress[msgId] = true;
   finish = handleFinish(this, msgId, next, done);
+
   return fileGitHubIssue(this, message, rule, response)
     .then(finish, finish);
 };
@@ -98,4 +105,10 @@ function handleFinish(that, msgId, next, done) {
     delete that.inProgress[msgId];
     next(done);
   };
+}
+
+function alreadyProcessed(message, successReaction) {
+  return message.item.message.reactions.find(function(reaction) {
+    return reaction.name === successReaction;
+  });
 }

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -48,9 +48,7 @@ Middleware.prototype.execute = function(context, next, done) {
 };
 
 function messageId(message) {
-  if (message) {
-    return message.item.channel + ':' + message.item.message.ts;
-  }
+  return message.item.channel + ':' + message.item.message.ts;
 }
 
 Middleware.prototype.findMatchingRule = function(message) {

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -42,7 +42,7 @@ Middleware.prototype.execute = function(context, next, done) {
   this.inProgress[msgId] = true;
   finish = handleFinish(this, msgId, next, done);
 
-  return fileGitHubIssue(this, message, rule, response)
+  return fileGitHubIssue(this, msgId, message, rule.githubRepository, response)
     .then(finish, finish);
 };
 
@@ -76,24 +76,24 @@ Middleware.prototype.parseMetadata = function(message) {
   return result;
 };
 
-function fileGitHubIssue(that, message, rule, response) {
+function fileGitHubIssue(that, msgId, message, githubRepository, response) {
   var metadata = that.parseMetadata(message),
       resolve, reject;
 
   resolve = function(issueUrl) {
-    log('GitHub success: ' + issueUrl);
+    log(msgId + ': GitHub success: ' + issueUrl);
     response.reply('created: ' + issueUrl);
   };
 
   reject = function(err) {
-    log('GitHub error: ' + err.message);
+    log(msgId + ': GitHub error: ' + err.message);
     response.reply('failed to create a GitHub issue in ' +
-      that.githubClient.user + '/' + rule.githubRepository + ': ' +
+      that.githubClient.user + '/' + githubRepository + ': ' +
       err.message);
   };
 
-  log('making GitHub request for ' + metadata.url);
-  return that.githubClient.fileNewIssue(metadata, rule.githubRepository)
+  log(msgId + ': making GitHub request for ' + metadata.url);
+  return that.githubClient.fileNewIssue(metadata, githubRepository)
     .then(resolve, reject);
 }
 

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -36,5 +36,5 @@ Rule.prototype.issueAlreadyFiled = function(message) {
 Rule.prototype.channelMatches = function(message, slackClient) {
   var channels = this.channelNames;
   return channels === undefined ||
-    channels.indexOf(slackClient.getChannelName(message.item.channel)) != -1;
+    channels.indexOf(slackClient.getChannelName(message.item.channel)) !== -1;
 };

--- a/scripts/slack-github-issues.js
+++ b/scripts/slack-github-issues.js
@@ -23,7 +23,7 @@ var log = require('../lib/log');
 module.exports = function(robot) {
   var config = new Config(),
       impl = new Middleware(
-        config.rules,
+        config,
         new SlackClient(robot.adapter.client, config),
         new GitHubClient(config)),
       middleware = function(context, next, done) {

--- a/test/config-test.js
+++ b/test/config-test.js
@@ -5,9 +5,9 @@
 'use strict';
 
 var Config = require('../lib/config');
+var scriptName = require('../package.json').name;
 var helpers = require('./helpers');
 var LogHelper = require('./helpers/log-helper');
-var scriptName = require('../package.json').name;
 var chai = require('chai');
 var path = require('path');
 
@@ -65,16 +65,16 @@ describe('Config', function() {
           'missing successReaction',
           'missing rules'
         ],
-        errorMessage = 'Invalid configuration:\n  ' + errors.join('\n  ');
+        errorMsg = 'Invalid configuration:\n  ' + errors.join('\n  ');
 
-    expect(function() { newConfig({}); }).to.throw(errorMessage);
-    expect(logHelper.messages).to.eql([[scriptName + ': ' + errorMessage]]);
+    expect(function() { newConfig({}); }).to.throw(errorMsg);
+    expect(logHelper.messages).to.eql([scriptName + ': ' + errorMsg]);
   });
 
   it('should raise errors for missing required rules fields', function() {
     var config = helpers.baseConfig(),
         errors,
-        errorMessage;
+        errorMsg;
 
     delete config.rules[0].reactionName;
     delete config.rules[0].githubRepository;
@@ -83,16 +83,16 @@ describe('Config', function() {
       'rule 0 missing reactionName',
       'rule 0 missing githubRepository'
     ];
-    errorMessage = 'Invalid configuration:\n  ' + errors.join('\n  ');
+    errorMsg = 'Invalid configuration:\n  ' + errors.join('\n  ');
 
-    expect(function() { newConfig(config); }).to.throw(errorMessage);
-    expect(logHelper.messages).to.eql([[scriptName + ': ' + errorMessage]]);
+    expect(function() { newConfig(config); }).to.throw(errorMsg);
+    expect(logHelper.messages).to.eql([scriptName + ': ' + errorMsg]);
   });
 
   it('should raise errors for unknown properties', function() {
     var config = helpers.baseConfig(),
         errors,
-        errorMessage;
+        errorMsg;
 
     config.foo = {};
     config.bar = {};
@@ -110,10 +110,10 @@ describe('Config', function() {
       'rule 0 contains unknown property baz',
       'rule 3 contains unknown property quux',
     ];
-    errorMessage = 'Invalid configuration:\n  ' + errors.join('\n  ');
+    errorMsg = 'Invalid configuration:\n  ' + errors.join('\n  ');
 
-    expect(function() { newConfig(config); }).to.throw(errorMessage);
-    expect(logHelper.messages).to.eql([[scriptName + ': ' + errorMessage]]);
+    expect(function() { newConfig(config); }).to.throw(errorMsg);
+    expect(logHelper.messages).to.eql([scriptName + ': ' + errorMsg]);
   });
 
   it('should load from HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH', function() {
@@ -121,8 +121,8 @@ describe('Config', function() {
         config = newConfig();
     expect(JSON.stringify(config)).to.eql(JSON.stringify(baseConfig));
     expect(logHelper.messages).to.eql([
-      [scriptName + ': loading config from ' +
-       process.env.HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH]
+      scriptName + ': loading config from ' +
+        process.env.HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH
     ]);
   });
 
@@ -134,7 +134,7 @@ describe('Config', function() {
     config = newConfig();
     expect(JSON.stringify(config)).to.eql(JSON.stringify(defaultConfig));
     expect(logHelper.messages).to.eql([
-      [scriptName + ': loading config from config/slack-github-issues.json']
+      scriptName + ': loading config from config/slack-github-issues.json'
     ]);
   });
 });

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -85,8 +85,14 @@ exports = module.exports = {
     };
   },
 
+
   logMessage: function(message) {
     return scriptName + ': ' + exports.MSG_ID + ': ' + message;
+  },
+
+  matchingRuleLogMessage: function() {
+    var matchingRule = exports.baseConfig().rules[2];
+    return exports.logMessage('matches rule: ' + JSON.stringify(matchingRule));
   },
 
   githubLogMessage: function() {

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -3,6 +3,7 @@
 'use strict';
 
 var SlackClient = require('../../lib/slack-client');
+var scriptName = require('../../package.json').name;
 var testConfig = require('./test-config.json');
 var Hubot = require('hubot');
 var SlackBot = require('hubot-slack');
@@ -82,5 +83,28 @@ exports = module.exports = {
       title: exports.metadata().title,
       body:  exports.metadata().url
     };
+  },
+
+  logMessage: function(message) {
+    return scriptName + ': ' + exports.MSG_ID + ': ' + message;
+  },
+
+  githubLogMessage: function() {
+    return exports.logMessage('making GitHub request for ' + exports.PERMALINK);
+  },
+
+  successLogMessage: function() {
+    return exports.logMessage('created: ' + exports.ISSUE_URL);
+  },
+
+  failureMessage: function(message) {
+    var params = exports.githubParams();
+
+    return 'failed to create a GitHub issue in ' +
+      params.user + '/' + params.repo + ': ' + message;
+  },
+
+  failureLogMessage: function(message) {
+    return exports.logMessage(exports.failureMessage(message));
   }
 };

--- a/test/helpers/log-helper.js
+++ b/test/helpers/log-helper.js
@@ -3,6 +3,8 @@
 module.exports = LogHelper;
 
 var sinon = require('sinon');
+var chai = require('chai');
+chai.should();
 
 function LogHelper() {
 }
@@ -12,6 +14,8 @@ LogHelper.prototype.captureLog = function() {
 };
 
 LogHelper.prototype.restoreLog = function() {
-  this.messages = console.log.args;
+  this.messages = console.log.args.map(function(callArgs) {
+    return callArgs.join(' ');
+  });
   console.log.restore();
 };

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -92,6 +92,7 @@ describe('Integration test', function() {
       ]);
 
       logMessages.should.eql(configLogMessages.concat([
+        helpers.matchingRuleLogMessage(),
         helpers.githubLogMessage(),
         helpers.successLogMessage()
       ]));
@@ -112,7 +113,9 @@ describe('Integration test', function() {
         ['hubot', '@mikebland failed to create a GitHub issue ' +
          'in 18F/handbook: test failure']
       ]);
+
       logMessages.should.eql(configLogMessages.concat([
+        helpers.matchingRuleLogMessage(),
         helpers.githubLogMessage(),
         helpers.failureLogMessage('test failure')
       ]));

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -37,8 +37,8 @@ describe('Integration test', function() {
       [scriptName + ': loading config from ' + configPath],
       [scriptName + ': registered receiveMiddleware']
     ];
-    githubLogMessage = scriptName + ': making GitHub request for ' +
-      helpers.metadata().url;
+    githubLogMessage = scriptName + ': ' + helpers.MSG_ID +
+      ': making GitHub request for ' + helpers.PERMALINK;
   });
 
   after(function() {
@@ -95,7 +95,8 @@ describe('Integration test', function() {
       ]);
       logMessages.should.eql(configLogMessages.concat([
         [githubLogMessage],
-        [scriptName + ': GitHub success: ' + helpers.ISSUE_URL]
+        [scriptName + ': ' + helpers.MSG_ID + ': GitHub success: ' +
+         helpers.ISSUE_URL]
       ]));
     });
   });
@@ -116,7 +117,7 @@ describe('Integration test', function() {
       ]);
       logMessages.should.eql(configLogMessages.concat([
         [githubLogMessage],
-        [scriptName + ': GitHub error: test failure']
+        [scriptName + ': ' + helpers.MSG_ID + ': GitHub error: test failure']
       ]));
     });
   });

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -25,8 +25,7 @@ describe('Integration test', function() {
       slackClient = new SlackClient(
        new FakeSlackClientImpl('handbook'), testConfig),
       githubParams = helpers.githubParams(),
-      logHelper, logMessages,
-      configLogMessages, githubLogMessage;
+      logHelper, logMessages, configLogMessages;
 
   before(function() {
     var configPath = path.join(__dirname, 'helpers', 'test-config.json');
@@ -34,11 +33,9 @@ describe('Integration test', function() {
     process.env.HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH = configPath;
     process.env.HUBOT_GITHUB_TOKEN = '<18F-github-token>';
     configLogMessages = [
-      [scriptName + ': loading config from ' + configPath],
-      [scriptName + ': registered receiveMiddleware']
+      scriptName + ': loading config from ' + configPath,
+      scriptName + ': registered receiveMiddleware'
     ];
-    githubLogMessage = scriptName + ': ' + helpers.MSG_ID +
-      ': making GitHub request for ' + helpers.PERMALINK;
   });
 
   after(function() {
@@ -93,10 +90,10 @@ describe('Integration test', function() {
         ['mikebland', 'evergreen_tree'],
         ['hubot', '@mikebland created: ' + helpers.ISSUE_URL]
       ]);
+
       logMessages.should.eql(configLogMessages.concat([
-        [githubLogMessage],
-        [scriptName + ': ' + helpers.MSG_ID + ': GitHub success: ' +
-         helpers.ISSUE_URL]
+        helpers.githubLogMessage(),
+        helpers.successLogMessage()
       ]));
     });
   });
@@ -116,8 +113,8 @@ describe('Integration test', function() {
          'in 18F/handbook: test failure']
       ]);
       logMessages.should.eql(configLogMessages.concat([
-        [githubLogMessage],
-        [scriptName + ': ' + helpers.MSG_ID + ': GitHub error: test failure']
+        helpers.githubLogMessage(),
+        helpers.failureLogMessage('test failure')
       ]));
     });
   });

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -159,8 +159,10 @@ describe('Middleware', function() {
         next.calledWith(hubotDone).should.be.true;
         hubotDone.called.should.be.false;
         logHelper.messages.should.eql([
-          [scriptName + ': making GitHub request for ' + helpers.PERMALINK],
-          [scriptName + ': GitHub success: ' + helpers.ISSUE_URL]
+          [scriptName + ': ' + helpers.MSG_ID +
+           ': making GitHub request for ' + helpers.PERMALINK],
+          [scriptName + ': ' + helpers.MSG_ID +
+           ': GitHub success: ' + helpers.ISSUE_URL]
         ]);
       }).should.notify(done);
     });
@@ -184,8 +186,10 @@ describe('Middleware', function() {
         next.calledWith(hubotDone).should.be.true;
         hubotDone.called.should.be.false;
         logHelper.messages.should.eql([
-          [scriptName + ': making GitHub request for ' + helpers.PERMALINK],
-          [scriptName + ': GitHub error: test failure']
+          [scriptName + ': ' + helpers.MSG_ID +
+           ': making GitHub request for ' + helpers.PERMALINK],
+          [scriptName + ': ' + helpers.MSG_ID +
+           ': GitHub error: test failure']
         ]);
       }).should.notify(done);
     });

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -9,7 +9,6 @@ var GitHubClient = require('../lib/github-client');
 var SlackClient = require('../lib/slack-client');
 var scriptName = require('../package.json').name;
 var helpers = require('./helpers');
-var config = require('./helpers/test-config.json');
 var FakeSlackClientImpl = require('./helpers/fake-slack-client-impl');
 var LogHelper = require('./helpers/log-helper');
 var sinon = require('sinon');
@@ -23,14 +22,14 @@ chai.use(chaiAsPromised);
 chai.use(chaiThings);
 
 describe('Middleware', function() {
-  var rules, slackClientImpl, githubClient, middleware;
+  var config, slackClientImpl, githubClient, middleware;
 
   beforeEach(function() {
-    rules = helpers.baseConfig().rules;
+    config = helpers.baseConfig();
     slackClientImpl = new FakeSlackClientImpl('handbook');
     githubClient = new GitHubClient(helpers.baseConfig(), {});
     middleware = new Middleware(
-      rules, new SlackClient(slackClientImpl, config), githubClient);
+      config, new SlackClient(slackClientImpl, config), githubClient);
   });
 
   describe('parseMetadata', function() {
@@ -44,7 +43,7 @@ describe('Middleware', function() {
   describe('findMatchingRule', function() {
     it('should find the rule matching the message', function() {
       var message = helpers.reactionAddedMessage().rawMessage,
-          expected = rules[rules.length - 1],
+          expected = config.rules[config.rules.length - 1],
           result = middleware.findMatchingRule(message);
 
       result.reactionName.should.equal(expected.reactionName);
@@ -217,6 +216,27 @@ describe('Middleware', function() {
         logHelper.messages.should.include.something.that.deep.equals(
           inProgressLogMessage);
       }).should.notify(done);
+    });
+
+    it('should not file another issue for the same message when ' +
+      'one is already filed ', function() {
+      var result, alreadyFiledLogMessage;
+
+      message.rawMessage.item.message.reactions.push({
+        name: config.successReaction,
+        count: 1,
+        users: [ helpers.USER_ID ]
+      });
+
+      logHelper.captureLog();
+      result = middleware.execute(context, next, hubotDone);
+      logHelper.restoreLog();
+      expect(result).to.be.undefined;
+
+      alreadyFiledLogMessage = [
+        scriptName + ': ' + helpers.MSG_ID + ': already processed'];
+      logHelper.messages.should.include.something.that.deep.equals(
+        alreadyFiledLogMessage);
     });
   });
 });

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -159,6 +159,7 @@ describe('Middleware', function() {
         next.calledWith(hubotDone).should.be.true;
         hubotDone.called.should.be.false;
         logHelper.messages.should.eql([
+          helpers.matchingRuleLogMessage(),
           helpers.githubLogMessage(),
           helpers.successLogMessage(),
         ]);
@@ -184,6 +185,7 @@ describe('Middleware', function() {
         next.calledWith(hubotDone).should.be.true;
         hubotDone.called.should.be.false;
         logHelper.messages.should.eql([
+          helpers.matchingRuleLogMessage(),
           helpers.githubLogMessage(),
           helpers.failureLogMessage('test failure')
         ]);

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -5,9 +5,9 @@
 'use strict';
 
 var Middleware = require('../lib/middleware');
+var scriptName = require('../package.json').name;
 var GitHubClient = require('../lib/github-client');
 var SlackClient = require('../lib/slack-client');
-var scriptName = require('../package.json').name;
 var helpers = require('./helpers');
 var FakeSlackClientImpl = require('./helpers/fake-slack-client-impl');
 var LogHelper = require('./helpers/log-helper');
@@ -159,10 +159,8 @@ describe('Middleware', function() {
         next.calledWith(hubotDone).should.be.true;
         hubotDone.called.should.be.false;
         logHelper.messages.should.eql([
-          [scriptName + ': ' + helpers.MSG_ID +
-           ': making GitHub request for ' + helpers.PERMALINK],
-          [scriptName + ': ' + helpers.MSG_ID +
-           ': GitHub success: ' + helpers.ISSUE_URL]
+          helpers.githubLogMessage(),
+          helpers.successLogMessage(),
         ]);
       }).should.notify(done);
     });
@@ -186,10 +184,8 @@ describe('Middleware', function() {
         next.calledWith(hubotDone).should.be.true;
         hubotDone.called.should.be.false;
         logHelper.messages.should.eql([
-          [scriptName + ': ' + helpers.MSG_ID +
-           ': making GitHub request for ' + helpers.PERMALINK],
-          [scriptName + ': ' + helpers.MSG_ID +
-           ': GitHub error: test failure']
+          helpers.githubLogMessage(),
+          helpers.failureLogMessage('test failure')
         ]);
       }).should.notify(done);
     });
@@ -215,8 +211,8 @@ describe('Middleware', function() {
         logHelper.restoreLog();
         fileNewIssue.calledOnce.should.be.true;
 
-        inProgressLogMessage = [
-          scriptName + ': ' + helpers.MSG_ID + ': already in progress'];
+        inProgressLogMessage = scriptName + ': ' + helpers.MSG_ID +
+          ': already in progress';
         logHelper.messages.should.include.something.that.deep.equals(
           inProgressLogMessage);
       }).should.notify(done);
@@ -237,8 +233,8 @@ describe('Middleware', function() {
       logHelper.restoreLog();
       expect(result).to.be.undefined;
 
-      alreadyFiledLogMessage = [
-        scriptName + ': ' + helpers.MSG_ID + ': already processed'];
+      alreadyFiledLogMessage = scriptName + ': ' + helpers.MSG_ID +
+        ': already processed';
       logHelper.messages.should.include.something.that.deep.equals(
         alreadyFiledLogMessage);
     });


### PR DESCRIPTION
Depends on #22. Part of #17. This prevents new GitHub requests from being filed when a message has already had a GitHub issue filed. The next commit will add `config.successResponse` to messages that have had GitHub issues successfully filed.

cc: @afeld @ccostino @jeremiak 