### PR TITLE
Only include the message URL in the issue body

### DIFF
--- a/lib/github-client.js
+++ b/lib/github-client.js
@@ -24,13 +24,12 @@ function createGitHubApi(config) {
   return api;
 }
 
-GitHubClient.prototype.fileNewIssue = function(metadata, repository, text) {
-  var issueBody = 'From ' + metadata.url + ':\n\n' + text,
-      params = {
+GitHubClient.prototype.fileNewIssue = function(metadata, repository) {
+  var params = {
         user: this.user,
         repo: repository,
         title: metadata.title,
-        body: issueBody
+        body: metadata.url
       },
       that = this;
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -70,7 +70,6 @@ function fileGitHubIssue(that, message, rule, response) {
   };
 
   log('making GitHub request for ' + metadata.url);
-  return that.githubClient.fileNewIssue(metadata,
-    rule.githubRepository, that.slackClient.getMessageText(response.message))
+  return that.githubClient.fileNewIssue(metadata, rule.githubRepository)
     .then(resolve, reject);
 }

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -31,10 +31,6 @@ SlackClient.prototype.getUserName = function(userId) {
   return this.client.getUserByID(userId).name;
 };
 
-SlackClient.prototype.getMessageText = function(message) {
-  return message.text;
-};
-
 SlackClient.prototype.getReactions = function(channel, timestamp) {
   return makeApiCall(this, 'reactions.get',
     { channel: channel, timestamp: timestamp });

--- a/test/github-client-test.js
+++ b/test/github-client-test.js
@@ -39,8 +39,7 @@ describe('GitHubClient', function() {
     var issueUrl = 'https://github.com/18F/handbook/issues/1',
         api = new FakeGitHubApi(issueUrl, null, helpers.githubParams()),
         client = new GitHubClient(config, api);
-    return client.fileNewIssue(
-      helpers.metadata(), 'handbook', helpers.reactionAddedMessage().text)
+    return client.fileNewIssue(helpers.metadata(), 'handbook')
       .should.eventually.equal(issueUrl);
   });
 

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -78,8 +78,7 @@ exports = module.exports = {
       user:  '18F',
       repo:  'handbook',
       title: exports.metadata().title,
-      body:  'From ' + exports.metadata().url + ':\n\n' +
-        exports.reactionAddedMessage().text
+      body:  exports.metadata().url
     };
   }
 };

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -90,8 +90,7 @@ describe('Middleware', function() {
       hubotDone = sinon.spy();
 
       metadata = helpers.metadata();
-      expectedFileNewIssueArgs = [metadata, 'handbook',
-        helpers.reactionAddedMessage().rawMessage.item.message.text];
+      expectedFileNewIssueArgs = [metadata, 'handbook'];
       logHelper = new LogHelper();
     });
 


### PR DESCRIPTION
Per @andrewmaier, since some content may be internal-only, we should include only the link to the message in the issue rather than its actual content.

cc: @ccostino @afeld @jeremiak 