### PR TITLE
Use GET with the Slack API, not POST

### DIFF
--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -87,7 +87,7 @@ function handleResponse(res, resolve, reject) {
   });
   res.on('end', function() {
     if (res.statusCode >=200 && res.statusCode <= 300) {
-      resolve(result);
+      resolve(JSON.parse(result));
     } else {
       reject(new Error('received ' + res.statusCode +
         ' response from Slack API: ' + result));

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var http = require('http');
+var https = require('https');
 
 module.exports = SlackClient;
 
@@ -42,15 +43,19 @@ SlackClient.prototype.addSuccessReaction = function(channel, timestamp) {
 };
 
 function makeApiCall(that, method, params) {
+  var requestFactory = (that.protocol === 'https:') ? https : http;
+
   return new Promise(function(resolve, reject) {
-    var paramsStr, req;
+    var paramsStr, httpOptions, req;
 
     params.token = process.env.HUBOT_SLACK_TOKEN;
     paramsStr = JSON.stringify(params);
+    httpOptions = getHttpOptions(that, method, paramsStr);
 
-    req = http.request(getHttpOptions(that, method, paramsStr), function(res) {
+    req = requestFactory.request(httpOptions, function(res) {
       handleResponse(res, resolve, reject);
     });
+
     req.setTimeout(that.timeout);
     req.on('error', function(err) {
       reject(new Error('failed to make Slack API request: ' + err.message));

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -3,6 +3,7 @@
 
 var http = require('http');
 var https = require('https');
+var querystring = require('querystring');
 
 module.exports = SlackClient;
 
@@ -46,11 +47,10 @@ function makeApiCall(that, method, params) {
   var requestFactory = (that.protocol === 'https:') ? https : http;
 
   return new Promise(function(resolve, reject) {
-    var paramsStr, httpOptions, req;
+    var httpOptions, req;
 
     params.token = process.env.HUBOT_SLACK_TOKEN;
-    paramsStr = JSON.stringify(params);
-    httpOptions = getHttpOptions(that, method, paramsStr);
+    httpOptions = getHttpOptions(that, method, params);
 
     req = requestFactory.request(httpOptions, function(res) {
       handleResponse(method, res, resolve, reject);
@@ -61,21 +61,17 @@ function makeApiCall(that, method, params) {
       reject(new Error('failed to make Slack API request for method ' +
         method + ': ' + err.message));
     });
-    req.end(paramsStr);
+    req.end();
   });
 }
 
-function getHttpOptions(that, method, postDataString) {
+function getHttpOptions(that, method, queryParams) {
   return {
     protocol: that.protocol,
     host: that.host,
     port: that.port,
-    path: '/api/' + method,
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Content-Length': postDataString.length
-    }
+    path: '/api/' + method + '?' + querystring.stringify(queryParams),
+    method: 'GET'
   };
 }
 

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -53,12 +53,13 @@ function makeApiCall(that, method, params) {
     httpOptions = getHttpOptions(that, method, paramsStr);
 
     req = requestFactory.request(httpOptions, function(res) {
-      handleResponse(res, resolve, reject);
+      handleResponse(method, res, resolve, reject);
     });
 
     req.setTimeout(that.timeout);
     req.on('error', function(err) {
-      reject(new Error('failed to make Slack API request: ' + err.message));
+      reject(new Error('failed to make Slack API request for method ' +
+        method + ': ' + err.message));
     });
     req.end(paramsStr);
   });
@@ -78,7 +79,7 @@ function getHttpOptions(that, method, postDataString) {
   };
 }
 
-function handleResponse(res, resolve, reject) {
+function handleResponse(method, res, resolve, reject) {
   var result = '';
 
   res.setEncoding('utf8');
@@ -86,11 +87,20 @@ function handleResponse(res, resolve, reject) {
     result = result + chunk;
   });
   res.on('end', function() {
-    if (res.statusCode >=200 && res.statusCode <= 300) {
-      resolve(JSON.parse(result));
+    var parsed;
+
+    if (res.statusCode >= 200 && res.statusCode < 300) {
+      parsed = JSON.parse(result);
+
+      if (parsed.ok) {
+        resolve(parsed);
+      } else {
+        reject(new Error('Slack API method ' + method + ' failed: ' +
+          parsed.error));
+      }
     } else {
       reject(new Error('received ' + res.statusCode +
-        ' response from Slack API: ' + result));
+        ' response from Slack API method ' + method + ': ' + result));
     }
   });
 }

--- a/test/helpers/fake-slack-api-server.js
+++ b/test/helpers/fake-slack-api-server.js
@@ -30,7 +30,7 @@ module.exports = {
             ', actual body ' + actualBody;
         }
         res.statusCode = statusCode;
-        res.end(payload);
+        res.end(JSON.stringify(payload));
       });
     });
     server.listen(0);

--- a/test/helpers/fake-slack-api-server.js
+++ b/test/helpers/fake-slack-api-server.js
@@ -3,13 +3,14 @@
 var http = require('http');
 
 module.exports = {
-  launch: function launch(expectedUrl, expectedParams, statusCode, payload) {
+  launch: function launch(urlsToResponses) {
     var server = new http.Server(function(req, res) {
-      var postBody = '', expectedBody, actualBody;
+      var responseData = urlsToResponses[req.url],
+          postBody = '';
 
-      if (req.url !== expectedUrl) {
+      if (!responseData) {
         res.statusCode = 500;
-        res.end('expected URL ' + expectedUrl + ', actual URL ' + req.url);
+        res.end('unexpected URL: ' + req.url);
         return;
       }
 
@@ -18,11 +19,13 @@ module.exports = {
       });
 
       req.on('end', function() {
-        expectedBody = JSON.stringify(expectedParams);
-        actualBody = JSON.stringify(JSON.parse(postBody));
+        var statusCode = responseData.statusCode,
+            payload = responseData.payload,
+            expectedBody = JSON.stringify(responseData.expectedBody),
+            actualBody = JSON.stringify(JSON.parse(postBody));
 
         if (actualBody !== expectedBody) {
-          statusCode = 500;
+          res.statusCode = 500;
           payload = 'expected body ' + expectedBody +
             ', actual body ' + actualBody;
         }

--- a/test/helpers/fake-slack-client-impl.js
+++ b/test/helpers/fake-slack-client-impl.js
@@ -6,21 +6,21 @@ var Channel = require('slack-client/src/channel');
 var Team = require('slack-client/src/team');
 var User = require('slack-client/src/user');
 
-module.exports = FakeSlackClient;
+module.exports = FakeSlackClientImpl;
 
-function FakeSlackClient(channelName) {
+function FakeSlackClientImpl(channelName) {
   this.channelName = channelName;
   this.team = new Team(this, '18F', '18F', '18f');
 }
 
-FakeSlackClient.prototype.getChannelByID = function(channelId) {
+FakeSlackClientImpl.prototype.getChannelByID = function(channelId) {
   this.channelId = channelId;
   // https://api.slack.com/types/channel
   return new Channel(this,
     { id: channelId, name: this.channelName, 'is_channel': true });
 };
 
-FakeSlackClient.prototype.getUserByID = function(userId) {
+FakeSlackClientImpl.prototype.getUserByID = function(userId) {
   this.userId = userId;
   // https://api.slack.com/types/user
   return new User(this, { id: userId, name: 'mikebland' });

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -12,7 +12,7 @@ var testConfig = require('./helpers/test-config.json');
 var LogHelper = require('./helpers/log-helper');
 var SlackClient = require('../lib/slack-client');
 var GitHubClient = require('../lib/github-client');
-var FakeSlackClient = require('./helpers/fake-slack-client');
+var FakeSlackClientImpl = require('./helpers/fake-slack-client-impl');
 var FakeGitHubApi = require('./helpers/fake-github-api');
 
 var path = require('path');
@@ -23,7 +23,7 @@ chai.should();
 describe('Integration test', function() {
   var middlewareImpl = null,
       slackClient = new SlackClient(
-       new FakeSlackClient('handbook'), testConfig),
+       new FakeSlackClientImpl('handbook'), testConfig),
       githubParams = helpers.githubParams(),
       logHelper, logMessages,
       configLogMessages, githubLogMessage;

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -10,7 +10,7 @@ var SlackClient = require('../lib/slack-client');
 var scriptName = require('../package.json').name;
 var helpers = require('./helpers');
 var config = require('./helpers/test-config.json');
-var FakeSlackClient = require('./helpers/fake-slack-client');
+var FakeSlackClientImpl = require('./helpers/fake-slack-client-impl');
 var LogHelper = require('./helpers/log-helper');
 var sinon = require('sinon');
 var chai = require('chai');
@@ -21,22 +21,22 @@ chai.should();
 chai.use(chaiAsPromised);
 
 describe('Middleware', function() {
-  var rules, slackClient, githubClient, middleware;
+  var rules, slackClientImpl, githubClient, middleware;
 
   beforeEach(function() {
     rules = helpers.baseConfig().rules;
-    slackClient = new FakeSlackClient('handbook');
+    slackClientImpl = new FakeSlackClientImpl('handbook');
     githubClient = new GitHubClient(helpers.baseConfig(), {});
     middleware = new Middleware(
-      rules, new SlackClient(slackClient, config), githubClient);
+      rules, new SlackClient(slackClientImpl, config), githubClient);
   });
 
   describe('parseMetadata', function() {
     it('should parse GitHub request metadata from a message', function() {
       middleware.parseMetadata(helpers.reactionAddedMessage().rawMessage)
         .should.eql(helpers.metadata());
-      slackClient.channelId.should.equal(helpers.CHANNEL_ID);
-      slackClient.userId.should.equal(helpers.USER_ID);
+      slackClientImpl.channelId.should.equal(helpers.CHANNEL_ID);
+      slackClientImpl.userId.should.equal(helpers.USER_ID);
     });
   });
 

--- a/test/rule-test.js
+++ b/test/rule-test.js
@@ -8,7 +8,7 @@ var Rule = require('../lib/rule');
 var SlackClient = require('../lib/slack-client');
 var helpers = require('./helpers');
 var config = require('./helpers/test-config.json');
-var FakeSlackClient = require('./helpers/fake-slack-client');
+var FakeSlackClientImpl = require('./helpers/fake-slack-client-impl');
 var chai = require('chai');
 
 var expect = chai.expect;
@@ -24,7 +24,7 @@ describe('Rule', function() {
   it('should match a channel-specific message', function() {
     var rule = new Rule(helpers.configRule()),
         message = helpers.reactionAddedMessage().rawMessage,
-        client = new FakeSlackClient('hub');
+        client = new FakeSlackClientImpl('hub');
     expect(rule.match(message, new SlackClient(client, config))).to.be.true;
     expect(client.channelId).to.eql(helpers.CHANNEL_ID);
   });
@@ -32,7 +32,7 @@ describe('Rule', function() {
   it('should match a non-channel-specific message', function() {
     var rule = new Rule(helpers.configRule()),
         message = helpers.reactionAddedMessage().rawMessage,
-        client = new FakeSlackClient('not-the-hub');
+        client = new FakeSlackClientImpl('not-the-hub');
     delete rule.channelName;
     expect(rule.match(message, new SlackClient(client, config))).to.be.true;
     expect(client.channelId).to.be.undefined;
@@ -41,7 +41,7 @@ describe('Rule', function() {
   it('should ignore a message if its name does not match', function() {
     var rule = new Rule(helpers.configRule()),
         message = helpers.reactionAddedMessage().rawMessage,
-        client = new FakeSlackClient('hub');
+        client = new FakeSlackClientImpl('hub');
     message.name = 'sad-face';
     expect(rule.match(message, new SlackClient(client, config))).to.be.false;
     expect(client.channelId).to.be.undefined;
@@ -50,7 +50,7 @@ describe('Rule', function() {
   it('should ignore a message if this is not the first reaction', function() {
     var rule = new Rule(helpers.configRule()),
         message = helpers.reactionAddedMessage().rawMessage,
-        client = new FakeSlackClient('hub');
+        client = new FakeSlackClientImpl('hub');
     message.item.message.reactions[0].count = 2;
     expect(rule.match(message, new SlackClient(client, config))).to.be.false;
     expect(client.channelId).to.be.undefined;
@@ -59,7 +59,7 @@ describe('Rule', function() {
   it('should ignore a message if the inner reaction isn\'t found', function() {
     var rule = new Rule(helpers.configRule()),
         message = helpers.reactionAddedMessage().rawMessage,
-        client = new FakeSlackClient('hub');
+        client = new FakeSlackClientImpl('hub');
     message.item.message.reactions.pop();
     expect(rule.match(message, new SlackClient(client, config))).to.be.false;
     expect(client.channelId).to.be.undefined;
@@ -68,7 +68,7 @@ describe('Rule', function() {
   it('should ignore a message if the channel doesn\'t match', function() {
     var rule = new Rule(helpers.configRule()),
         message = helpers.reactionAddedMessage().rawMessage,
-        client = new FakeSlackClient('not-the-hub');
+        client = new FakeSlackClientImpl('not-the-hub');
     expect(rule.match(message, new SlackClient(client, config))).to.be.false;
     expect(client.channelId).to.eql(helpers.CHANNEL_ID);
   });

--- a/test/slack-client-test.js
+++ b/test/slack-client-test.js
@@ -30,7 +30,7 @@ describe('SlackClient', function() {
 
   beforeEach(function() {
     slackApiServer = undefined;
-    payload = '{ "message": "Hello, world!" }';
+    payload = JSON.stringify({ 'message': 'Hello, world!' });
   });
 
   afterEach(function() {
@@ -40,8 +40,14 @@ describe('SlackClient', function() {
   });
 
   createServer = function(expectedUrl, expectedParams, statusCode, payload) {
-    slackApiServer = launchServer(expectedUrl, expectedParams,
-      statusCode, payload);
+    var urlsToResponses = {};
+
+    urlsToResponses[expectedUrl] = {
+      expectedBody: expectedParams,
+      statusCode: statusCode,
+      payload: payload
+    };
+    slackApiServer = launchServer(urlsToResponses);
     slackClient.port = slackApiServer.address().port;
   };
 

--- a/test/slack-client-test.js
+++ b/test/slack-client-test.js
@@ -43,7 +43,7 @@ describe('SlackClient', function() {
     var urlsToResponses = {};
 
     urlsToResponses[expectedUrl] = {
-      expectedBody: expectedParams,
+      expectedParams: expectedParams,
       statusCode: statusCode,
       payload: payload
     };

--- a/test/slack-client-test.js
+++ b/test/slack-client-test.js
@@ -30,7 +30,7 @@ describe('SlackClient', function() {
 
   beforeEach(function() {
     slackApiServer = undefined;
-    payload = JSON.stringify({ 'message': 'Hello, world!' });
+    payload = { 'message': 'Hello, world!' };
   });
 
   afterEach(function() {
@@ -75,8 +75,8 @@ describe('SlackClient', function() {
       // 300-family requests will currently fail as well.
       createServer('/api/reactions.get', params, 404, 'Not found');
       return slackClient.getReactions(helpers.CHANNEL_ID, helpers.TIMESTAMP)
-        .should.be.rejectedWith('received 404 response from Slack API: ' +
-          'Not found');
+        .should.be.rejectedWith(Error,
+          'received 404 response from Slack API: "Not found"');
     });
   });
 

--- a/test/slack-client-test.js
+++ b/test/slack-client-test.js
@@ -30,7 +30,7 @@ describe('SlackClient', function() {
 
   beforeEach(function() {
     slackApiServer = undefined;
-    payload = { 'message': 'Hello, world!' };
+    payload = { ok: true, message: 'Hello, world!' };
   });
 
   afterEach(function() {
@@ -68,15 +68,26 @@ describe('SlackClient', function() {
 
     it('should fail to make a request if the server is down', function() {
       return slackClient.getReactions(helpers.CHANNEL_ID, helpers.TIMESTAMP)
-        .should.be.rejectedWith('failed to make Slack API request:');
+        .should.be.rejectedWith('failed to make Slack API request ' +
+          'for method reactions.get:');
     });
 
     it('should make an unsuccessful request', function() {
-      // 300-family requests will currently fail as well.
+      payload = {
+        ok: false,
+        error: 'not_authed'
+      };
+      createServer('/api/reactions.get', params, 200, payload);
+      return slackClient.getReactions(helpers.CHANNEL_ID, helpers.TIMESTAMP)
+        .should.be.rejectedWith(Error, 'Slack API method reactions.get ' +
+          'failed: ' + payload.error);
+    });
+
+    it('should make a request that produces a non-200 response', function() {
       createServer('/api/reactions.get', params, 404, 'Not found');
       return slackClient.getReactions(helpers.CHANNEL_ID, helpers.TIMESTAMP)
-        .should.be.rejectedWith(Error,
-          'received 404 response from Slack API: "Not found"');
+        .should.be.rejectedWith(Error, 'received 404 response from ' +
+          'Slack API method reactions.get: "Not found"');
     });
   });
 


### PR DESCRIPTION
Also ensures that HTTP is used in the tests while HTTPS is used in production, and refactors some of the SlackClient-related test objects.

cc: @ccostino @DavidEBest @jeremiak @afeld 