### PR TITLE
Allow for a list of matching channel names

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You'll need to create a JSON file conforming to the following schema:
   * *reactionName* name of the reaction emoji triggering the rule
   * *githubRepository*: GitHub repository belonging to *githubUser* to which
     to post issues
-  * *channelName (optional)*: name of the Slack channel triggering the rule;
+  * *channelNames (optional)*: name of the Slack channels triggering the rule;
     leave undefined to match messages in _any_ Slack channel
 
 For example:

--- a/lib/config.js
+++ b/lib/config.js
@@ -30,7 +30,8 @@ var schema = {
     githubRepository: 'GitHub repository to which to post issues'
   },
   optionalRulesFields: {
-    channelName: 'name of the Slack channel triggering the rule'
+    channelNames: 'names of the Slack channels triggering the rules; ' +
+      'leave undefined to match messages in any Slack channel'
   }
 };
 

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -34,10 +34,7 @@ Rule.prototype.issueAlreadyFiled = function(message) {
 };
 
 Rule.prototype.channelMatches = function(message, slackClient) {
-  var channel;
-
-  if (this.channelName) {
-    channel = slackClient.getChannelName(message.item.channel);
-  }
-  return channel === this.channelName;
+  var channels = this.channelNames;
+  return channels === undefined ||
+    channels.indexOf(slackClient.getChannelName(message.item.channel)) != -1;
 };

--- a/test/config-test.js
+++ b/test/config-test.js
@@ -49,7 +49,7 @@ describe('Config', function() {
     configWithChannelRule.rules.push({
       'reactionName': 'smiley',
       'githubRepository': '18F/hubot-slack-github-issues',
-      'channelName': 'hub'
+      'channelNames': ['hub']
     });
     config = newConfig(configWithChannelRule);
     expect(JSON.stringify(config)).to.eql(
@@ -100,7 +100,7 @@ describe('Config', function() {
     config.rules.push({
       'reactionName': 'smiley',
       'githubRepository': '18F/hubot-slack-github-issues',
-      'channelName': 'hub',
+      'channelNames': ['hub'],
       'quux': {}
     });
 

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -30,7 +30,7 @@ exports = module.exports = {
     return {
       reactionName: exports.REACTION,
       githubRepository: 'hubot-slack-github-issues',
-      channelName: 'hub'
+      channelNames: ['hub']
     };
   },
 

--- a/test/helpers/test-config.json
+++ b/test/helpers/test-config.json
@@ -7,7 +7,7 @@
     {
       "reactionName": "evergreen_tree",
       "githubRepository": "hub",
-      "channelName": "hub"
+      "channelNames": ["hub"]
     },
 
     {

--- a/test/rule-test.js
+++ b/test/rule-test.js
@@ -33,7 +33,7 @@ describe('Rule', function() {
     var rule = new Rule(helpers.configRule()),
         message = helpers.reactionAddedMessage().rawMessage,
         client = new FakeSlackClientImpl('not-the-hub');
-    delete rule.channelName;
+    delete rule.channelNames;
     expect(rule.match(message, new SlackClient(client, config))).to.be.true;
     expect(client.channelId).to.be.undefined;
   });


### PR DESCRIPTION
It's painful to repeat a configuration rule multiple times when the only thing that's changed is the `channelName`.

cc: @ccostino @jeremiak @afeld @DavidEBest @andrewmaier 