### PR TITLE
Extract success and failure handlers into execute

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -41,10 +41,11 @@ Middleware.prototype.execute = function(context, next, done) {
 
   this.inProgress[msgId] = true;
   log(msgId + ': matches rule: ' + JSON.stringify(rule));
-  finish = handleFinish(this, msgId, next, done);
+  finish = handleFinish(this, msgId, response, next, done);
 
-  return fileGitHubIssue(this, msgId, message, rule.githubRepository, response)
-    .then(finish, finish);
+  return fileGitHubIssue(this, msgId, message, rule.githubRepository)
+    .then(handleSuccess(finish))
+    .catch(handleFailure(this, rule.githubRepository, finish));
 };
 
 function messageId(message) {
@@ -75,41 +76,41 @@ Middleware.prototype.parseMetadata = function(message) {
   return result;
 };
 
-function fileGitHubIssue(that, msgId, message, githubRepository, response) {
-  var metadata = that.parseMetadata(message),
-      resolve, reject;
-
-  resolve = function(issueUrl) {
-    var message = 'created: ' + issueUrl;
-    log(msgId + ': ' + message);
-    response.reply(message);
-  };
-
-  reject = function(err) {
-    var message = 'failed to create a GitHub issue in ' +
-      that.githubClient.user + '/' + githubRepository + ': ' +
-      err.message;
-    log(msgId + ': ' + message);
-    response.reply(message);
-  };
+function fileGitHubIssue(that, msgId, message, githubRepository) {
+  var metadata = that.parseMetadata(message);
 
   log(msgId + ': making GitHub request for ' + metadata.url);
-  return that.githubClient.fileNewIssue(metadata, githubRepository)
-    .then(resolve, reject);
-}
-
-function handleFinish(that, msgId, next, done) {
-  return function(err) {
-    if (err) {
-      log(err);
-    }
-    delete that.inProgress[msgId];
-    next(done);
-  };
+  return that.githubClient.fileNewIssue(metadata, githubRepository);
 }
 
 function alreadyProcessed(message, successReaction) {
   return message.item.message.reactions.find(function(reaction) {
     return reaction.name === successReaction;
   });
+}
+
+function handleSuccess(finish) {
+  return function(issueUrl) {
+    finish('created: ' + issueUrl);
+    return Promise.resolve(issueUrl);
+  };
+}
+
+function handleFailure(that, githubRepository, finish) {
+  return function(err) {
+    var message = 'failed to create a GitHub issue in ' +
+      that.githubClient.user + '/' + githubRepository + ': ' + err.message;
+
+    finish(message);
+    return Promise.reject(new Error(message));
+  };
+}
+
+function handleFinish(that, msgId, response, next, done) {
+  return function(reply) {
+    response.reply(reply);
+    log(msgId + ': ' + reply);
+    delete that.inProgress[msgId];
+    next(done);
+  };
 }

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -85,7 +85,6 @@ exports = module.exports = {
     };
   },
 
-
   logMessage: function(message) {
     return scriptName + ': ' + exports.MSG_ID + ': ' + message;
   },

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -108,10 +108,11 @@ describe('Integration test', function() {
     });
 
     it('should fail to create a GitHub issue', function() {
+      var errorMessage = helpers.failureMessage('test failure');
+
       this.room.messages.should.eql([
         ['mikebland', 'evergreen_tree'],
-        ['hubot', '@mikebland failed to create a GitHub issue ' +
-         'in 18F/handbook: test failure']
+        ['hubot', '@mikebland ' + errorMessage ]
       ]);
 
       logMessages.should.eql(configLogMessages.concat([

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -149,7 +149,7 @@ describe('Middleware', function() {
         return;
       }
 
-      result.should.be.fulfilled.then(function() {
+      result.should.become(helpers.ISSUE_URL).then(function() {
         logHelper.restoreLog();
         fileNewIssue.calledOnce.should.be.true;
         fileNewIssue.firstCall.args.should.eql(expectedFileNewIssueArgs);
@@ -167,6 +167,8 @@ describe('Middleware', function() {
     });
 
     it('should parse a message but fail to file an issue', function(done) {
+      var errorMessage = helpers.failureMessage('test failure');
+
       fileNewIssue.returns(Promise.reject(new Error('test failure')));
       result = doExecute(done);
 
@@ -174,13 +176,12 @@ describe('Middleware', function() {
         return;
       }
 
-      result.should.be.fulfilled.then(function() {
+      result.should.be.rejectedWith(Error, errorMessage).then(function() {
         logHelper.restoreLog();
         fileNewIssue.calledOnce.should.be.true;
         fileNewIssue.firstCall.args.should.eql(expectedFileNewIssueArgs);
         reply.calledOnce.should.be.true;
-        reply.firstCall.args.should.eql(
-          ['failed to create a GitHub issue in 18F/handbook: test failure']);
+        reply.firstCall.args.should.eql([errorMessage]);
         next.calledOnce.should.be.true;
         next.calledWith(hubotDone).should.be.true;
         hubotDone.called.should.be.false;
@@ -194,7 +195,7 @@ describe('Middleware', function() {
 
     it('should not file another issue for the same message when ' +
       'one is in progress', function(done) {
-      fileNewIssue.returns(Promise.resolve(metadata.url));
+      fileNewIssue.returns(Promise.resolve(helpers.ISSUE_URL));
       result = doExecute(done);
 
       if (!result) {
@@ -207,7 +208,7 @@ describe('Middleware', function() {
           'issue being filed when one was in progress'));
       }
 
-      return result.should.be.fulfilled.then(function() {
+      return result.should.become(helpers.ISSUE_URL).then(function() {
         var inProgressLogMessage;
 
         logHelper.restoreLog();


### PR DESCRIPTION
The handlers also return Promises to help make the tests more meaningful.

This seemed worth extracting into its own PR, before the subsequent edits to incorporate Promises that make Slack API calls.

cc: @ccostino @DavidEBest @jeremiak 