### PR TITLE
Suggested revisions to readme for usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ message appeared.
 
 ## Installation
 
+Here are instructions for installing this plugin and putting it into use. If you'd like to set up a local copy for development without deploying the plugin, skip to the instructions at [Developing](#developing) (you don't need to create a Hubot instance, a Slack user, or a GitHub user until you intend to deploy the script).
+
 1. Install [Node.js](https://nodejs.org/) on your system. This plugin requires
-   version 4.2 or greater or version 5 or greater. You may wish to use a
-   version manager such as [nvm](https://github.com/creationix/nvm) to manage
-   different Node.js versions.
+   version 4.2 or greater or version 5 or greater. You may wish to first install a
+   version manager such as [nvm](https://github.com/creationix/nvm) to manage and install different Node.js versions.
 
 1. [Create your own Hubot instance](https://hubot.github.com/docs/) if you
    haven't already done so. Note that you do _not_ need to install Redis to
@@ -48,24 +49,8 @@ message appeared.
    $ npm install '18f/hubot-slack#3.4.2-handle-reaction-added' \
        hubot-slack-github-issues --save
    ```
-
-1. Include the plugin in your `external-scripts.json`.
-   ```json
-   [
-     "hubot-slack-github-issues"
-   ]
-   ```
-1. [Set up Slack and GitHub users](#setting-up-slack-and-github-users).
-
-1. [Configure the plugin](#configuration).
-
-1. Set the [environment variables](#environment-variables).
-
-1. Run `bin/hubot` or otherwise deploy to your preferred environment.
-
-### Note regarding near-term dependencies
-
-This plugin depends upon
+   
+   **Note:** This plugin depends upon
 [18F/hubot-slack#3.4.2-handle-reaction-added](https://github.com/18F/hubot-slack/tree/3.4.2-handle-reaction-added),
 which in turn depends upon
 [18F/node-slack-client#1.5.0-handle-reaction-added](https://github.com/18F/node-slack-client/tree/1.5.0-handle-reaction-added).
@@ -73,19 +58,23 @@ These packages are custom forks of the
 [hubot-slack](https://www.npmjs.com/package/hubot-slack) and 
 [slack-client](https://www.npmjs.com/package/slack-client) packages that have
 had support for the [`reaction_added`
-event](https://api.slack.com/events/reaction_added) patched in.
-
-When those official packages have been updated to include `reaction_added`
+event](https://api.slack.com/events/reaction_added) patched in. When those official packages have been updated to include `reaction_added`
 support, this plugin will be updated to use those packages instead of the
 custom versions.
 
-### Setting up Slack and GitHub users
+1. Include the plugin in your `external-scripts.json`.
+   ```json
+   [
+     "hubot-slack-github-issues"
+   ]
+   ```
+1. Set up Slack and GitHub users:
 
-If you haven't done so already, create a [Slack bot
+   	If you haven't done so already, create a [Slack bot
 user](https://api.slack.com/bot-users). Use the bot's API token as the value
 for the [`HUBOT_SLACK_TOKEN` environment variable](#environment-variables).
 
-Then [create a GitHub
+   	Then [create a GitHub
 account](https://help.github.com/articles/signing-up-for-a-new-github-account/)
 dedicated to filing issues on behalf of the script, such as
 [18f-bot](https://github.com/18f-bot). If desired, add this account to your GitHub
@@ -94,12 +83,16 @@ token](https://help.github.com/articles/creating-an-access-token-for-command-lin
 for this user and use it as the value for the [`HUBOT_GITHUB_TOKEN`
 environment variable](#environment-variables).
 
-**If you wish to use this script with private GitHub repositories**, [add your
+    **If you wish to use this script with private GitHub repositories**, [add your
 GitHub user as a collaborator](https://help.github.com/articles/adding-outside-collaborators-to-repositories-in-your-organization/)
 with [read access](https://help.github.com/articles/repository-permission-levels-for-an-organization/)
 to each repository. Alternatively, you can [add your GitHub user to a
 team](https://help.github.com/articles/adding-organization-members-to-a-team/)
 with access to private repositories instead.
+
+1. Configure the plugin by [creating a JSON configuration file with these items](#configuration) and setting the [environment variables](#environment-variables).
+
+1. Run `bin/hubot` or otherwise deploy to your preferred environment.
 
 ## Configuration
 
@@ -162,7 +155,7 @@ following conditions for each set of rules pertaining to a `reactionName`:
 
 ### Environment variables
 
-The following environment variables must also be set:
+You must also set the following environment variables (how to do that depends on the operating system and shell that you use; [here's an example guide for OS X with the default bash shell](http://osxdaily.com/2015/07/28/set-enviornment-variables-mac-os-x/)):
 
 * `HUBOT_GITHUB_TOKEN`: personal API token for the GitHub user
 * `HUBOT_SLACK_TOKEN`: API token for the Slack bot user

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ message appeared.
 
 ## Installation
 
-Here are instructions for installing this plugin and putting it into use. If you'd like to set up a local copy for development without deploying the plugin, skip to the instructions at [Developing](#developing) (you don't need to create a Hubot instance, a Slack user, or a GitHub user until you intend to deploy the script).
+Here are instructions for installing this plugin and putting it into use. If you'd like to set up a local copy for development without deploying the plugin, follow step #1 and then skip to the instructions at [Developing](#developing) (you don't need to create a Hubot instance, a Slack bot user, a GitHub user, a configuration file, or environment variables until you intend to deploy the script).
 
 1. Install [Node.js](https://nodejs.org/) on your system. This plugin requires
    version 4.2 or greater or version 5 or greater. You may wish to first install a
@@ -62,7 +62,7 @@ event](https://api.slack.com/events/reaction_added) patched in. When those offic
 support, this plugin will be updated to use those packages instead of the
 custom versions.
 
-1. Include the plugin in your `external-scripts.json`.
+1. Include the plugin in `external-scripts.json` in your Hubot repository:
    ```json
    [
      "hubot-slack-github-issues"
@@ -90,7 +90,7 @@ to each repository. Alternatively, you can [add your GitHub user to a
 team](https://help.github.com/articles/adding-organization-members-to-a-team/)
 with access to private repositories instead.
 
-1. Configure the plugin by [creating a JSON configuration file with these items](#configuration) and setting the [environment variables](#environment-variables).
+1. Configure the plugin by [creating a JSON configuration file with these items](#configuration) and [setting these environment variables](#environment-variables).
 
 1. Run `bin/hubot` or otherwise deploy to your preferred environment.
 
@@ -166,9 +166,8 @@ The following environment variables are optional:
 
 ## Developing
 
-Install Node.js per the [installation instructions](#installation). You don't
-need to create a Hubot instance, nor do you need to create Slack or GitHub
-users, until you intend to deploy the script.
+Install Node.js per the [installation instructions (step #1)](#installation). You don't
+need to create a Hubot instance, a Slack bot user, a GitHub user, a configuration file, or environment variables until you intend to deploy the script.
 
 After cloning this repository, do the following to ensure your installation is
 in a good state:

--- a/README.md
+++ b/README.md
@@ -2,13 +2,9 @@
 
 [![Build Status](https://travis-ci.org/18F/hubot-slack-github-issues.svg?branch=master)](https://travis-ci.org/18F/hubot-slack-github-issues)
 
-[Hubot](https://hubot.github.com/) plugin that creates
-[GitHub](https://github.com/) issues from [Slack](https://slack.com/) messages
-that receive a specific emoji reaction.
+When a [Slack](https://slack.com/) chat message receives a specific emoji reaction, this [Hubot](https://hubot.github.com/) plugin creates a [GitHub](https://github.com/) issue with a link to that message.
 
-This plugin is for use by organizations that use Slack to communicate and who
-use GitHub to track issues. The goal is to enable team members to document or
-to act upon important parts of conversations more easily.
+This plugin is for teams who use Slack to communicate and GitHub to track issues. It provides an easy way to file an issue (just add a specific emoji to a message), which helps team members quickly document or act upon important parts of conversations. For example, 18F [tags Slack messages with an evergreen tree](https://18f.gsa.gov/2015/12/08/using-emoji-for-knowledge-sharing/) when we notice future new hires should see that information.
 
 <figure>
 <img src='./example.png' alt='Usage example' /><br/>
@@ -20,10 +16,10 @@ channel.</figcaption>
 
 ## How it works
 
-It works by registering [receive middleware](https://hubot.github.com/docs/scripting/#receive-middleware)
-that listens for [`reaction_added` events](https://api.slack.com/events/reaction_added).
+This plugin works by registering [Hubot receive middleware](https://hubot.github.com/docs/scripting/#receive-middleware)
+that listens for [Slack `reaction_added` events](https://api.slack.com/events/reaction_added).
 When team members add an emoji reaction to a message, the resulting event is
-matched against a set of [configuration rules](#configuration).
+matched against a set of [plugin configuration rules](#configuration).
 If the event matches a rule, the plugin will [retrieve the list of
 reactions](https://api.slack.com/methods/reactions.get) for the message.
 


### PR DESCRIPTION
Here are suggestions for making this readme better. Some things I changed - totally fine with me if you prefer to take some of these changes but not all of them:

* I rewrote the intro sentence to be a tiny chronological story ("when a thing happens, this does a thing") so that it's more understandable at a glance if you don't already know what "Hubot" is.
* I linked our example of evergreen trees for newcomer documentation.
* I integrated the two shorter side-note sections (about near-term dependencies and Slack/GitHub user creation) into the main Installation instructions, to minimize readers having to jump back and forth between sections while reading.
* I added a note to the top of the Installation instructions suggesting that people can skip to Developing if they don't need to deploy their own instance.
* I added a little extra context and specific language where possible, to assist readers who have less background knowledge - for example, adding a link about environment variables and changing "receive middleware" to "Hubot receive middleware".

The Installation section seems to be missing two steps: “this is a good time to clone this repository locally” and “this is a good time to follow the Developing instructions if you intend to make changes to the code later”. I'm not sure where you'd want to put these steps, so I left them out for now. Could it make sense to integrate the Developing instructions into the beginning of the Installation instructions (and say "skip the rest if you don't need to deploy this right now")?

Good to note: at this point I haven't actually tested the instructions on my computer, I'm just revising based on reading them!