### PR TITLE
Eliminate HTTP server in the integration test

### DIFF
--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -89,7 +89,7 @@ describe('Integration test', function() {
 
     logHelper = new LogHelper();
     logHelper.captureLog();
-    this.room = scriptHelper.createRoom({ name: 'handbook' });
+    this.room = scriptHelper.createRoom({ httpd: false, name: 'handbook' });
     logHelper.restoreLog();
     logMessages = logHelper.messages.slice();
     middlewareImpl = this.room.robot.middleware.receive.stack[0].impl;
@@ -124,7 +124,6 @@ describe('Integration test', function() {
 
   afterEach(function() {
     githubApiServer.close();
-    this.room.destroy();
   });
 
   context('an evergreen_tree reaction to a message', function() {


### PR DESCRIPTION
Per https://github.com/mtsmfm/hubot-test-helper#httpd, we don't really need Hubot to launch its own HTTP server in the test. Shaves off ~70ms on a Late 2013 MacBook Pro with a 2.6 GHz Intel Core i5 and 16 GB 1600 MHz DDR3 RAM.

cc: @ccostino @afeld @jeremiak 