### PR TITLE
Local, Travis, and CodeClimate coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ node_js:
 - "node"
 - "4.2"
 script: npm run lint && npm test && test/hubot-smoke-test.bash
+after_success: if [ "${TRAVIS_BRANCH}" = "master" ]; then npm run report-cov; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ node_js:
 script: npm run lint && npm test && test/hubot-smoke-test.bash
 after_success:
 - npm run report-coveralls
-- if [ "${TRAVIS_BRANCH}" = "master" ]; then npm run report-cov-cc; fi
+- if [[ "${TRAVIS_BRANCH}" = "master" && "#{TRAVIS_PULL_REQUEST}" = "false" ]]; then npm run report-cov-cc; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,8 @@ node_js:
 - "node"
 - "4.2"
 script: npm run lint && npm test && test/hubot-smoke-test.bash
-after_success: if [ "${TRAVIS_BRANCH}" = "master" ]; then npm run report-cov; fi
+after_success: |
+  npm run report-coveralls
+  if [ "${TRAVIS_BRANCH}" = "master" ]; then
+    npm run report-cov-cc
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ node_js:
 - "node"
 - "4.2"
 script: npm run lint && npm test && test/hubot-smoke-test.bash
-after_success: |
-  npm run report-coveralls
-  if [ "${TRAVIS_BRANCH}" = "master" ]; then
-    npm run report-cov-cc
-  fi
+after_success:
+- npm run report-coveralls
+- if [ "${TRAVIS_BRANCH}" = "master" ]; then npm run report-cov-cc; fi

--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 
 [![NPM](https://nodei.co/npm/hubot-slack-github-issues.png?compact=true)](https://nodei.co/npm/hubot-slack-github-issues/)<br/>
 [![Build Status](https://travis-ci.org/18F/hubot-slack-github-issues.svg?branch=master)](https://travis-ci.org/18F/hubot-slack-github-issues)
-[![Code
-Climate](https://codeclimate.com/github/18F/hubot-slack-github-issues/badges/gpa.svg)](https://codeclimate.com/github/18F/hubot-slack-github-issues)
-[![Test
-Coverage](https://codeclimate.com/github/18F/hubot-slack-github-issues/badges/coverage.svg)](https://codeclimate.com/github/18F/hubot-slack-github-issues/coverage)
+[![Code Climate](https://codeclimate.com/github/18F/hubot-slack-github-issues/badges/gpa.svg)](https://codeclimate.com/github/18F/hubot-slack-github-issues)
+[![Coverage Status](https://coveralls.io/repos/18F/hubot-slack-github-issues/badge.svg?branch=master&service=github)](https://coveralls.io/github/18F/hubot-slack-github-issues?branch=master)
 
 When a [Slack](https://slack.com/) chat message receives a specific emoji reaction, this [Hubot](https://hubot.github.com/) plugin creates a [GitHub](https://github.com/) issue with a link to that message.
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,15 @@ with any string matching the tests you wish to run:
 $ npm test -- --grep 'Config'
 ```
 
+To generate a local coverage report, run:
+
+```sh
+$ COVERAGE=true npm test
+```
+
+This will place coverage data into the `coverage/` directory and generate an
+HTML report as `coverage/lcov-report/index.html`.
+
 If you'd like to contribute to this repository, please follow our
 [CONTRIBUTING guidelines](./CONTRIBUTING.md).
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,11 +40,7 @@ function getCoverageReportOptions() {
   var options;
 
   if (process.env.CI === 'true') {
-    options = { reporters: ['text'] };
-
-    if (process.env.TRAVIS_BRANCH === 'master') {
-      options.reporters.push('lcovonly');
-    }
+    options = { reporters: ['text', 'lcovonly'] };
   }
   return options;
 }

--- a/package.json
+++ b/package.json
@@ -17,13 +17,16 @@
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",
     "chai-things": "^0.2.0",
+    "codeclimate-test-reporter": "^0.1.1",
     "coffee-script": "^1.10.0",
     "gulp": "^3.9.0",
+    "gulp-istanbul": "^0.10.3",
     "gulp-jshint": "^2.0.0",
     "gulp-mocha": "^2.2.0",
     "hubot": "^2.17.0",
     "hubot-slack": "^3.4.2",
     "hubot-test-helper": "^1.3.0",
+    "istanbul": "^0.4.1",
     "jshint": "^2.8.0",
     "mocha": "^2.3.4",
     "sinon": "^1.17.2",
@@ -31,7 +34,8 @@
   },
   "scripts": {
     "test": "gulp test",
-    "lint": "gulp lint"
+    "lint": "gulp lint",
+    "report-cov": "codeclimate-test-reporter < coverage/lcov.info"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "chai-things": "^0.2.0",
     "codeclimate-test-reporter": "^0.1.1",
     "coffee-script": "^1.10.0",
+    "coveralls": "^2.11.6",
     "gulp": "^3.9.0",
     "gulp-istanbul": "^0.10.3",
     "gulp-jshint": "^2.0.0",
@@ -35,7 +36,8 @@
   "scripts": {
     "test": "gulp test",
     "lint": "gulp lint",
-    "report-cov": "codeclimate-test-reporter < coverage/lcov.info"
+    "report-cov-cc": "codeclimate-test-reporter < coverage/lcov.info",
+    "report-coveralls": "coveralls < coverage/lcov.info"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This enables local coverage reports via `COVERAGE=true npm test`, coverage reporting after successful Travis builds, and posting of coverage results to CodeClimate. Results are only posted to CodeClimate for successful builds of the `master` branch on Travis.

If this looks good to folks, I'll also incorporate it into [18F/unit-testing-node](https://github.com/18F/unit-testing-node/).

cc: @ccostino @DavidEBest @jeremiak @afeld @arowla 