### PR TITLE
Add utility program to create, validate configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,24 @@ to each repository. Alternatively, you can [add your GitHub user to a
 team](https://help.github.com/articles/adding-organization-members-to-a-team/)
 with access to private repositories instead.
 
-1. Configure the plugin by [creating a JSON configuration file with these items](#configuration) and [setting these environment variables](#environment-variables).
+1. Configure the plugin by [creating a JSON configuration file with these items](#configuration) and [setting these environment variables](#environment-variables). Validate the configuration by running `hubot-slack-github-issues validate path-to-config.json`.
 
 1. Run `bin/hubot` or otherwise deploy to your preferred environment.
 
 ## Configuration
 
-Create a JSON configuration file conforming to the following schema:
+The configuration file can reside at the default path of
+`config/slack-github-issues.json` within your Hubot installation, or can be
+specified via the `HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH` environment
+variable. To create the file from a template, run:
+
+```sh
+$ hubot-slack-github-issues print-template > config/slack-github-issues.json
+```
+
+### Schema
+
+The JSON configuration file must conform to the following schema:
 
 * **githubUser**: GitHub organization or username owning all repositories
 * **githubTimeout**: GitHub API timeout limit in milliseconds
@@ -129,13 +140,26 @@ For example:
 }
 ```
 
-This file can reside at the default path of `config/slack-github-issues.json`
-within your Hubot installation, or can be specified via the
-`HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH` environment variable.
-
 For a more complete example, see
 [`test/helpers/test-config.json`](./test/helpers/test-config.json) in this
 repository.
+
+### Validating the config file
+
+To validate the config file before deploying, run the following (replacing
+`config/slack-github-issues.json` with whatever path you chose earlier):
+
+```sh
+$ hubot-slack-github-issues validate config/slack-github-issues.json
+```
+
+If it passes, you will see:
+
+```sh
+config/slack-github-issues.json: OK
+```
+
+Otherwise, an error message will report all schema and constraint violations.
 
 ### Configuration constraints
 

--- a/bin/hubot-slack-github-issues
+++ b/bin/hubot-slack-github-issues
@@ -30,12 +30,13 @@ showHelp = (option === '-h' || option === '--help' || option === 'help');
 showVersion = (option === '-v' || option === '--version' ||
   option === 'version');
 
+if (showHelp) {
+  console.log(usage);
+} else if (showVersion) {
+  console.log(packageInfo.name + ' v' + packageInfo.version);
+}
+
 if (showHelp || showVersion) {
-  if (showHelp) {
-    console.log(usage);
-  } else if (showVersion) {
-    console.log(packageInfo.name + ' v' + packageInfo.version);
-  }
   process.exit(0);
 }
 

--- a/bin/hubot-slack-github-issues
+++ b/bin/hubot-slack-github-issues
@@ -1,0 +1,74 @@
+#! /usr/bin/env node
+
+var packageInfo = require('../package.json');
+var Config = require('../lib/config');
+var fs = require('fs');
+var path = require('path');
+var programName = path.basename(process.argv[1]);
+var option = process.argv[2];
+var usage = [
+  'Usage:',
+  '  ' + programName + ' [-hv|print-template]',
+  '  ' + programName + ' validate <config.json>',
+  '',
+  'Where:',
+  '  -h, --help, help        show this help',
+  '  -v, --version, version  show version info',
+  '  print-template          print an example slack-github-issues.json config',
+  '  validate <config.json>  validate the specified config file',
+].join('\n');
+
+var showHelp, showVersion;
+
+if (option === 'print-template') {
+  var config = require('../config/slack-github-issues.json');
+  console.log(JSON.stringify(config, null, 2));
+  process.exit(0);
+}
+
+showHelp = (option === '-h' || option === '--help' || option === 'help');
+showVersion = (option === '-v' || option === '--version' ||
+  option === 'version');
+
+if (showHelp || showVersion) {
+  if (showHelp) {
+    console.log(usage);
+  } else if (showVersion) {
+    console.log(packageInfo.name + ' v' + packageInfo.version);
+  }
+  process.exit(0);
+}
+
+function exitWithError(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+if (option === 'validate') {
+  var configPath = process.argv[3],
+      fullConfigPath = path.resolve(configPath),
+      configData,
+      configuration;
+
+  if (configPath === undefined) {
+    exitWithError('validate: no config file path specified');
+  }
+
+  if (!fs.existsSync(fullConfigPath)) {
+    exitWithError(configPath + ': does not exist');
+  }
+
+  try {
+    configData = require(fullConfigPath);
+    configuration = new Config(configData);
+  } catch (err) {
+    exitWithError(err.message);
+  }
+  console.log(configPath + ': OK');
+
+} else {
+  if (process.argv.length !== 2) {
+    console.error('Invalid arguments:', process.argv.slice(2).join(' '));
+  }
+  exitWithError(usage);
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -63,7 +63,8 @@ gulp.task('test', TEST_DEPENDENCIES, function() {
 });
 
 gulp.task('lint', function() {
-  return gulp.src(['*.js', 'scripts/**/*.js', 'lib/**/*.js', 'test/**/*.js'])
+  return gulp.src([
+    'bin/*', '*.js', 'scripts/**/*.js', 'lib/**/*.js', 'test/**/*.js'])
     .pipe(jshint())
     .pipe(jshint.reporter('default'));
 });

--- a/lib/config.js
+++ b/lib/config.js
@@ -54,7 +54,6 @@ Config.prototype.validate = function() {
 
   if (errors.length !== 0) {
     errMsg = 'Invalid configuration:\n  ' + errors.join('\n  ');
-    log(errMsg);
     throw new Error(errMsg);
   }
 };

--- a/test/config-test.js
+++ b/test/config-test.js
@@ -5,9 +5,7 @@
 'use strict';
 
 var Config = require('../lib/config');
-var scriptName = require('../package.json').name;
 var helpers = require('./helpers');
-var LogHelper = require('./helpers/log-helper');
 var chai = require('chai');
 var path = require('path');
 
@@ -15,10 +13,9 @@ var expect = chai.expect;
 chai.should();
 
 describe('Config', function() {
-  var logHelper, newConfig;
+  var newConfig;
 
   before(function() {
-    logHelper = new LogHelper();
     delete process.env.HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH;
   });
 
@@ -27,12 +24,7 @@ describe('Config', function() {
   });
 
   newConfig = function(config) {
-    try {
-      logHelper.captureLog();
-      return new Config(config);
-    } finally {
-      logHelper.restoreLog();
-    }
+    return new Config(config);
   };
 
   it('should validate a valid configuration', function() {
@@ -52,7 +44,6 @@ describe('Config', function() {
         errorMessage = 'Invalid configuration:\n  ' + errors.join('\n  ');
 
     expect(function() { newConfig({}); }).to.throw(Error, errorMessage);
-    expect(logHelper.messages).to.eql([scriptName + ': ' + errorMessage]);
   });
 
   it('should raise errors for missing required rules fields', function() {
@@ -70,7 +61,6 @@ describe('Config', function() {
     errorMessage = 'Invalid configuration:\n  ' + errors.join('\n  ');
 
     expect(function() { newConfig(config); }).to.throw(Error, errorMessage);
-    expect(logHelper.messages).to.eql([scriptName + ': ' + errorMessage]);
   });
 
   it('should raise errors for unknown properties', function() {
@@ -97,7 +87,6 @@ describe('Config', function() {
     errorMessage = 'Invalid configuration:\n  ' + errors.join('\n  ');
 
     expect(function() { newConfig(config); }).to.throw(Error, errorMessage);
-    expect(logHelper.messages).to.eql([scriptName + ': ' + errorMessage]);
   });
 
   it('should load from HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH', function() {
@@ -109,10 +98,6 @@ describe('Config', function() {
     config = newConfig();
 
     expect(JSON.stringify(config)).to.eql(JSON.stringify(baseConfig));
-    expect(logHelper.messages).to.eql([
-      scriptName + ': loading config from ' +
-        process.env.HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH
-    ]);
   });
 
   it('should load from config/slack-github-issues.json by default', function() {
@@ -121,9 +106,6 @@ describe('Config', function() {
 
     config = newConfig();
     expect(JSON.stringify(config)).to.eql(JSON.stringify(defaultConfig));
-    expect(logHelper.messages).to.eql([
-      scriptName + ': loading config from config/slack-github-issues.json'
-    ]);
   });
 
   describe('checkForMisconfiguredRules', function() {
@@ -150,9 +132,6 @@ describe('Config', function() {
           .replace(/\n/g, '\n  ');
 
       expect(function() { newConfig(config); }).to.throw(errorMessage);
-      expect(logHelper.messages).to.eql([
-        scriptName + ': ' + errorMessage
-      ]);
     });
 
     it('should detect when rules are not sorted by channelNames', function() {
@@ -178,9 +157,6 @@ describe('Config', function() {
           .replace(/\n/g, '\n  ');
 
       expect(function() { newConfig(config); }).to.throw(errorMessage);
-      expect(logHelper.messages).to.eql([
-        scriptName + ': ' + errorMessage
-      ]);
     });
 
     it('should detect when rules are not sorted by repository', function() {
@@ -215,9 +191,6 @@ describe('Config', function() {
           .replace(/\n/g, '\n  ');
 
       expect(function() { newConfig(errorConfig); }).to.throw(errorMessage);
-      expect(logHelper.messages).to.eql([
-        scriptName + ': ' + errorMessage
-      ]);
     });
 
     it('should detect unsorted channel names', function() {
@@ -236,9 +209,6 @@ describe('Config', function() {
         '    handbook\n' +
         '    hub';
       expect(function() { newConfig(config); }).to.throw(errorMessage);
-      expect(logHelper.messages).to.eql([
-        scriptName + ': ' + errorMessage
-      ]);
     });
 
     it('should detect duplicate repos for same reaction', function() {
@@ -252,9 +222,6 @@ describe('Config', function() {
         '  duplicate repositories for evergreen_tree rules:\n' +
         '    handbook';
       expect(function() { newConfig(config); }).to.throw(errorMessage);
-      expect(logHelper.messages).to.eql([
-        scriptName + ': ' + errorMessage
-      ]);
     });
 
     it('should detect duplicate repos and channels for reaction', function() {
@@ -274,9 +241,6 @@ describe('Config', function() {
         '  duplicate channels for evergreen_tree rules:\n' +
         '    hub';
       expect(function() { newConfig(config); }).to.throw(errorMessage);
-      expect(logHelper.messages).to.eql([
-        scriptName + ': ' + errorMessage
-      ]);
     });
 
     it('should detect multiple all-channel rules for reaction', function() {
@@ -290,9 +254,6 @@ describe('Config', function() {
       errorMessage = 'Invalid configuration:\n' +
         '  multiple all-channel rules defined for evergreen_tree';
       expect(function() { newConfig(config); }).to.throw(errorMessage);
-      expect(logHelper.messages).to.eql([
-        scriptName + ': ' + errorMessage
-      ]);
     });
   });
 });


### PR DESCRIPTION
Also removes the `log()` call from `Config.validate()`, since Hubot and other tools creating the `Config` object can catch and log the thrown error.

cc: @ccostino @ertzeid @afeld 