### PR TITLE
Check for client.baseurl.protocol in GitHubClient

### DIFF
--- a/lib/github-client.js
+++ b/lib/github-client.js
@@ -42,7 +42,7 @@ function getHttpOptions(client, repository, paramsStr) {
 }
 
 function makeApiCall(client, metadata, repository) {
-  var requestFactory = (client.protocol === 'https:') ? https : http,
+  var requestFactory = (client.baseurl.protocol === 'https:') ? https : http,
       paramsStr = JSON.stringify({
         title: metadata.title,
         body: metadata.url


### PR DESCRIPTION
This was causing the `makeApiCall` function to choose the `http` module every time, since `client.protocol` is undefined. In production, users were getting the error: `Protocol "https:" not supported. Expected "http:".`

cc: @afeld @annahsebok 